### PR TITLE
Updated RN and attributes for 3.1.2 release

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -1,7 +1,7 @@
 :productname: Red Hat Quay
 :productshortname: Quay
 :productversion: 3
-:productmin: 3.1.1
+:productmin: 3.1.2
 ifeval::["{productname}" == "Project Quay"]
 :imagesdir: images
 endif::[]

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -1,3 +1,18 @@
+[[rn-3-102]]
+== Version 3.1.2
+Release Date: October 31, 2019
+
+Fixed:
+
+* Upgrade base image to latest rhel:7.7
+* Repository mirroring properly updates status
+* Application repositories in public namespaces shown in UI
+* Description of log operations in UI
+* Quay V3 upgrade fails with "id field missing from v1Compatibility JSON"
+* Security token for storage proxy properly URL encoded
+
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-102[Link to this Release]
+
 [[rn-3-101]]
 == Version 3.1.1
 Release Date: October 3, 2019


### PR DESCRIPTION
Updated release notes and attributes file (with version number). All books need to be rebuilt because of the attribute change