### PR TITLE
Fix missing two incorrect container versions.

### DIFF
--- a/manage_quay/master.adoc
+++ b/manage_quay/master.adoc
@@ -11,6 +11,7 @@ further configure and manage that deployment. Topics covered here include:
 * Setting notifications to alert you of a new {productname} release
 * Securing connections with SSL and TLS certificates
 * Configuring image security scanning with Clair
+// * Scan pods with the Container Security Operator
 * Mirroring images with repository mirroring
 * Sharing Quay images with a BitTorrent service
 * Authenticating users with LDAP
@@ -32,6 +33,8 @@ include::modules/proc_manage-security-scanning.adoc[leveloffset=+1]
 
 include::modules/proc_manage-clair-enable.adoc[leveloffset=+1]
 
+// include::modules/proc_container-security-operator-setup.adoc[leveloffset=+1]
+//
 include::modules/proc_manage-repomirror.adoc[leveloffset=+1]
 
 :context: bittorrent

--- a/modules/ref_deploy_quay_openshift.adoc
+++ b/modules/ref_deploy_quay_openshift.adoc
@@ -379,7 +379,7 @@ spec:
             secretName: quay-enterprise-secret
       containers:
       - name: quay-enterprise-app
-        image: quay.io/redhat/quay:{productmin}
+        image: quay.io/redhat/quay:v{productmin}
         ports:
         - containerPort: 8443
         volumeMounts:
@@ -604,7 +604,7 @@ spec:
         namespace: quay-enterprise
       spec:
         containers:
-        - image: quay.io/redhat/clair-jwt:v3.0.4
+        - image: quay.io/redhat/clair-jwt:v{productmin}
           imagePullPolicy: IfNotPresent
           name: clair-scanner
           ports:


### PR DESCRIPTION
A quay container lacked a "v" for the version number. clair-jwt lacked the version attribute.