### PR TITLE
Updated RN and attributes to Quay 3.2.1

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -1,7 +1,7 @@
 :productname: Red Hat Quay
 :productshortname: Quay
 :productversion: 3
-:productmin: 3.2.0
+:productmin: 3.2.1
 :imagesdir: ../images
 
 ifeval::["{productname}" == "Project Quay"]

--- a/modules/rn_3_20.adoc
+++ b/modules/rn_3_20.adoc
@@ -1,3 +1,17 @@
+[[rn-3-201]]
+== Version 3.2.1
+Release Date: February 10, 2020
+
+Fixed:
+
+* git: Remote code execution in recursive clones with nested submodules Security.
+(See link:https://access.redhat.com/security/cve/CVE-2019-1387[CVE-2019-1387].)
+
+* yarn: nodejs-yarn: Install functionality can be abused to generate arbitrary symlinks.
+(See link:https://access.redhat.com/security/cve/CVE-2019-10773[CVE-2019-10773].)
+
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-201[Link to this Release]
+
 [[rn-3-200]]
 == Version 3.2.0
 Release Date: December 17, 2019


### PR DESCRIPTION
Add release notes description for Quay 3.2.1 and updated attributes so all references to the current version (on things like quay containers) use 3.2.1