### PR TITLE
Closed small Quay 3.2 bugs

### DIFF
--- a/modules/proc_deploy_quay_add.adoc
+++ b/modules/proc_deploy_quay_add.adoc
@@ -105,13 +105,17 @@ The following procedure assumes you already have a running
 {productname} cluster on an OpenShift platform, with the {productname} Setup
 container running in your browser:
 
-. **Start the repo mirroring worker**: Start the quay container in `repomirror` mode as follows:
+. **Start the repo mirroring worker**: Start the quay container in `repomirror` mode.
+This example assumes you have configured TLS communications using a certificate
+that is currently stored in `/root/ca.crt`. If not, then remove the line that adds
+`/root/ca.crt` to the container:
 +
 [subs="verbatim,attributes"]
 ```
 $ docker run -d --name mirroring-worker \
-  -v /mnt/quay/config:/conf/stack quay.io/redhat/quay:v{productmin} \
-  repomirror
+  -v /mnt/quay/config:/conf/stack \
+  -v /root/ca.crt:/etc/pki/ca-trust/source/anchors/ca.crt \
+  quay.io/redhat/quay:v{productmin} repomirror
 ```
 . **Log into config tool**: Log into the {productname} Setup Web UI (config tool).
 . **Enable repository mirroring**: Scroll down the the Repository Mirroring section

--- a/modules/proc_deploy_quay_openshift.adoc
+++ b/modules/proc_deploy_quay_openshift.adoc
@@ -338,7 +338,7 @@ OpenShift should create a new pod and pick up the needed configuration. If that 
 unpack the configuration files (`tar xvf quay-config.tar.gz`) and add them
 manually to the secret:
 ```
-$ oc create secret generic quay-enterprise-secret -n quay-enterprise \
+$ oc create secret generic quay-enterprise-config-secret -n quay-enterprise \
      --from-file=config.yaml=/path/to/config.yaml \
      --from-file=ssl.key=/path/to/ssl.key \
      --from-file=ssl.cert=/path/to/ssl.cert

--- a/modules/proc_deploy_quay_single.adoc
+++ b/modules/proc_deploy_quay_single.adoc
@@ -42,12 +42,12 @@ active
 
 . **Open ports in firewall**: If you have a firewall running on your system,
 to access the Red Hat Quay config tool (port 8443) and application (ports 80 and 443)
-outside of the local system, run the following commands:
+outside of the local system, run the following commands (add `--zone=<yourzone>` for each command to open ports on a particular zone):
 +
 ....
-# firewall-cmd --permanent --zone=trusted --add-port=8443/tcp
-# firewall-cmd --permanent --zone=trusted --add-port=80/tcp
-# firewall-cmd --permanent --zone=trusted --add-port=443/tcp
+# firewall-cmd --permanent --add-port=8443/tcp
+# firewall-cmd --permanent --add-port=80/tcp
+# firewall-cmd --permanent --add-port=443/tcp
 # firewall-cmd --reload
 ....
 

--- a/modules/proc_use-api.adoc
+++ b/modules/proc_use-api.adoc
@@ -70,14 +70,25 @@ To create an OAuth access token so you can access the API for your organization:
 == Accessing your {productname} API from a web browser
 
 By enabling Swagger, you can access the API for your own {productname} instance through a web browser.
-This exposes the {productname} API explorer via the Swagger UI and this URL:
+This URL exposes the {productname} API explorer via the Swagger UI and this URL:
 
 ```
 https://<yourquayhost>/api/v1/discovery.
 ```
 
-To enable Swagger in your {productname} cluster, add the following line to the config.yaml on all
-nodes in the cluster and restart {productname}:
+That way of accessing the API does not include superuser endpoints that are available on
+{productname} installations. Here is an example of accessing a {productname} API interface
+running on the local system by running the  swagger-ui container image:
+
+```
+# export SERVER_HOSTNAME=<yourhostname>
+# podman run -p 8888:8080 -e API_URL=https://$SERVER_HOSTNAME:8443/api/v1/discovery docker.io/swaggerapi/swagger-ui
+```
+With the swagger-ui container running, open your web browser to localhost port 8888 to view
+API endpoints via the swagger-ui container.
+
+To avoid errors in the log such as "API calls must be invoked with an X-Requested-With header if called from a browser,"
+add the following line to the `config.yaml` on all nodes in the cluster and restart {productname}:
 
 ```
 BROWSER_API_CALLS_XHR_ONLY: false


### PR DESCRIPTION
Fixed the following Jira in this PR:
- Update docs with cert mount path for repo mirroring: https://issues.redhat.com/browse/PROJQUAY-5
- more detailed firewall explanations in basic quay install docs please: https://issues.redhat.com/browse/PROJQUAY-245
- Quay config secret missing word “config” in documentation: https://issues.redhat.com/browse/PROJQUAY-410
- Document running swagger for api exploration: https://issues.redhat.com/browse/PROJQUAY-425

Please also check these Jira, which were previously fixed for Quay 3.2, but never closed:
- Add details on how to use Quay API: https://issues.redhat.com/browse/PROJQUAY-409
- Documentation missing flag --privileged=true for quay-builder command: https://issues.redhat.com/browse/PROJQUAY-413
- Document the CSO: https://issues.redhat.com/browse/PROJQUAY-426


