### PR TITLE
Update proc_use-quay-build-workers-dockerfiles.adoc

### DIFF
--- a/modules/proc_use-quay-build-workers-dockerfiles.adoc
+++ b/modules/proc_use-quay-build-workers-dockerfiles.adoc
@@ -80,7 +80,7 @@ ifdef::upstream[]
 # docker run --restart on-failure \
   -e SERVER=ws://myquayenterprise \
   --privileged=true \
-  -v /mnt/docker.sock:/mnt/docker.sock \
+  -v /mnt/docker.sock:/var/run/docker.sock \
   <registry>/<repo>/quay-builder:{productminv}
 ....
 endif::upstream[]
@@ -91,7 +91,7 @@ ifdef::downstream[]
 # docker run --restart on-failure \
   -e SERVER=ws://myquayenterprise \
   --privileged=true \
-  -v /mnt/docker.sock:/mnt/docker.sock \
+  -v /mnt/docker.sock:/var/run/docker.sock \
   {productrepo}/quay-builder:{productminv}
 ....
 endif::downstream[]
@@ -106,7 +106,7 @@ If {productname} is setup to use a SSL certificate that is not globally trusted,
   -e SERVER=wss://myquayenterprise \
   --privileged=true \
   -v /path/to/ssl/rootCA.pem:/etc/pki/ca-trust/source/anchors/rootCA.pem \
-  -v /mnt/docker.sock:/mnt/docker.sock \
+  -v /mnt/docker.sock:/var/run/docker.sock \
   {productrepo}/quay-builder:{productminv}
 ....
 [[set-up-github-build]]


### PR DESCRIPTION
Small typo found in documentation: 
https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/use_red_hat_quay/index#run-the-build-worker-image 

Destination docker socket must be mounted on `/var/run/`
Source, at least in CentOS case is in `/run/` directory, so depends on the OS, but target is expected to be mounted on `/var/run/` directory unless it is passed as environment variable to docker run command e.g. `DOCKER_HOST=unix:///mnt/docker.sock` : 
https://github.com/quay/quay-builder/blob/be2ee7752c7133ff32680af5b09fdc599c89e9bb/cmd/quay-builder/main.go#L17

https://github.com/quay/quay-builder/blob/be2ee7752c7133ff32680af5b09fdc599c89e9bb/cmd/quay-builder/main.go#L38