### PR TITLE
RN for 3.2.2 and added producty attribute

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -15,7 +15,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :downstream:
 :productname: Red Hat Quay
 :productversion: 3
-:productmin: 3.2.1
-:productminv: v3.2.1
+:producty: 3.2
+:productmin: 3.2.2
+:productminv: v3.2.2
 :productrepo: quay.io/redhat
 endif::[]

--- a/modules/rn_1_12.adoc
+++ b/modules/rn_1_12.adoc
@@ -26,4 +26,4 @@ Release Date: September 10, 2015
 * Changed webhook notifications to also send client SSL certs (#374)
 * Improved internal test suite (#381, #374, #388, #455, #457)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-120[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-120[Link to this Release]

--- a/modules/rn_1_13.adoc
+++ b/modules/rn_1_13.adoc
@@ -9,7 +9,7 @@ Bug Fixes:
 
 Quay Enterprise v1.13.x contains long-running migrations and should be updated during a maintenance window where administrators will have several hours of time to dedicate to the database migrating. Quay Enterprise will not be available while these migrations run.
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/2.9/html-single/red_hat_quay_release_notes#rn-1-133[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-133[Link to this Release]
 
 
 [[rn-1-132]]
@@ -19,7 +19,7 @@ Release Date: November 3, 2015
 
 * Fixed 404 API calls redirecting to 404 page (#762)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/2.9/html-single/red_hat_quay_release_notes#rn-1-132[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-132[Link to this Release]
 
 [[rn-1-131]]
 == Version 1.13.1
@@ -29,7 +29,7 @@ Release Date: November 3, 2015
 * Fixed broken database migration (#759)
 * Added OpenGraph preview image (#750, #758)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/2.9/html-single/red_hat_quay_release_notes#rn-1-131[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-131[Link to this Release]
 
 [[rn-1-130]]
 == Version 1.13.0

--- a/modules/rn_1_14.adoc
+++ b/modules/rn_1_14.adoc
@@ -22,7 +22,7 @@ Bug Fixes:
 * Fixed unhandled exceptions in Queue
 * Fixed UI for dismissing notifications (#1094)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-141[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-141[Link to this Release]
 
 [[rn-1-140]]
 == Version 1.14.0
@@ -49,4 +49,4 @@ Bug fixes:
 * Fixed page titles (#952)
 * Fixed numerous builder failures
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-140[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-140[Link to this Release]

--- a/modules/rn_1_15.adoc
+++ b/modules/rn_1_15.adoc
@@ -7,7 +7,7 @@ Fixed:
 
 * Docker pushes with v2 sha mismatch were breaking v2 functionality (#1236)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-155[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-155[Link to this Release]
 
 [[rn-1-154]]
 == Version 1.15.4
@@ -24,7 +24,7 @@ Fixed:
 * Minor UI error in tag specific image view (#1222)
 * Notification logo (#1223)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-154[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-154[Link to this Release]
 
 [[rn-1-153]]
 == Version 1.15.3
@@ -43,7 +43,7 @@ Fixed:
 * Tests (#1190, #1184)
 * Setup tool storage engine validation (#1194)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-153[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-153[Link to this Release]
 
 [[rn-1-152]]
 == Version 1.15.2
@@ -62,7 +62,7 @@ Fixed:
 * Scope handling for Docker 1.8.3 (#1162)
 * Typos in docs (#1163, #1164)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-152[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-152[Link to this Release]
 
 [[rn-1-150]]
 == Version 1.15.0
@@ -75,4 +75,4 @@ Fixed:
 
 * Fix torrent hash calculation (#1142)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-150[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-150[Link to this Release]

--- a/modules/rn_1_16.adoc
+++ b/modules/rn_1_16.adoc
@@ -8,7 +8,7 @@ Changed:
 * Added ability to override secure cookie setting when using HTTPS protocol (#1712)
 
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-166[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-166[Link to this Release]
 
 [[rn-1-165]]
 == Version 1.16.5
@@ -37,7 +37,7 @@ Fixed:
 * Support for empty RDN in LDAP configuration (#1644)
 * Error raised on duplicate placements when replicating (#1633)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-165[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-165[Link to this Release]
 
 [[rn-1-164]]
 == Version 1.16.4
@@ -61,7 +61,7 @@ Fixed:
 * GitHub API URLs are properly stripped of trailing slashes (#1590)
 * Tutorial fails gracefully without Redis (#1587)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-164[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-164[Link to this Release]
 
 [[rn-1-163]]
 == Version 1.16.3
@@ -90,7 +90,7 @@ Fixed:
 * Removed hosted Quay.io status from Enterprise 500 page (#1548)
 * Performance of database queries (#1512)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-163[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-163[Link to this Release]
 
 [[rn-1-162]]
 == Version 1.16.2
@@ -110,7 +110,7 @@ Fixed:
 * Repository descriptions breaking log page styles (#1532)
 * Styles on Privacy and Terms of Service pages (#1531)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-162[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-162[Link to this Release]
 
 [[rn-1-161]]
 == Version 1.16.1
@@ -147,7 +147,7 @@ Fixed:
 * Handling of admin OAuth Scope (#1447)
 
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-161[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-161[Link to this Release]
 
 [[rn-1-160]]
 == Version 1.16.0
@@ -184,4 +184,4 @@ Fixed:
 * Unicode error when calculating new V1 IDs (#1239)
 * Error when turning on receipt emails (#1209)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-160[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-160[Link to this Release]

--- a/modules/rn_1_17.adoc
+++ b/modules/rn_1_17.adoc
@@ -17,7 +17,7 @@ Fixed:
 * Delete empty Swift chunks (#1844)
 * Handling of custom LDAP cert (#1846)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-171[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-171[Link to this Release]
 
 [[rn-1-170]]
 == Version 1.17.0
@@ -53,4 +53,4 @@ Fixed:
 * Non-admin users no longer default to organization-wide read (#1685)
 * Database performance (#1680, #1688, #1690, #1722, #1744, #1772)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-170[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-170[Link to this Release]

--- a/modules/rn_1_18.adoc
+++ b/modules/rn_1_18.adoc
@@ -7,7 +7,7 @@ Fixed:
 
 * Exception when using RADOS GW Storage driver (#2057)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-181[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-181[Link to this Release]
 
 [[rn-1-180]]
 == Version 1.18.0
@@ -30,4 +30,4 @@ Fixed:
 * Add feature flag to turn off requirement for team invitations (#1845)
 * Don't exception log for expected 404s in Swift storage (#1851)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-180[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-180[Link to this Release]

--- a/modules/rn_2_00.adoc
+++ b/modules/rn_2_00.adoc
@@ -11,7 +11,7 @@ Fixed:
 
 * Support for wildcard certs in the superuser config panel
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-005[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-005[Link to this Release]
 
 [[rn-2-004]]
 == Version 2.0.4
@@ -48,7 +48,7 @@ Regressed:
 
 * Support for wildcard certs in the superuser config panel
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-004[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-004[Link to this Release]
 
 [[rn-2-003]]
 == Version 2.0.3
@@ -67,7 +67,7 @@ Fixed:
 * Improve security scan performance (#2209)
 * Fix user lookup for external auth engines (#2206)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-003[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-003[Link to this Release]
 
 [[rn-2-002]]
 == Version 2.0.2
@@ -105,7 +105,7 @@ Regressed:
 
 * User lookup for external auth engines broken
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-002[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-002[Link to this Release]
 
 [[rn-2-001]]
 == Version 2.0.1
@@ -150,7 +150,7 @@ Regressed:
 
 * Superuser config panel cannot save
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-001[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-001[Link to this Release]
 
 [[rn-2-000]]
 == Version 2.0.0
@@ -184,4 +184,4 @@ Regressed:
 
 * Entity search broken under Postgres
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-000[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-000[Link to this Release]

--- a/modules/rn_2_10.adoc
+++ b/modules/rn_2_10.adoc
@@ -19,4 +19,4 @@ Fixed:
 * Display of expiration date for licenses with multiple entries (#2354)
 * V1 search compatibility (#2344)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-100[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-100[Link to this Release]

--- a/modules/rn_2_20.adoc
+++ b/modules/rn_2_20.adoc
@@ -29,4 +29,4 @@ Fixed:
 * Validation and installation of custom TLS certificates (#2473)
 * Garbage Collection corner case (#2404)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-200[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-200[Link to this Release]

--- a/modules/rn_2_30.adoc
+++ b/modules/rn_2_30.adoc
@@ -6,7 +6,7 @@ Added:
 
 * Always show tag expiration options in superuser panel
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-304[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-304[Link to this Release]
 
 [[rn-2-303]]
 == Version 2.3.3
@@ -25,7 +25,7 @@ Fixed:
 * Viewing of repositories with trust enabled caused a 500 (#2594, #2593)
 * Failure in setup tool when time machine config is not set (#2589)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-303[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-303[Link to this Release]
 
 [[rn-2-302]]
 == Version 2.3.2
@@ -47,7 +47,7 @@ Fixed:
 * Create New tooltip hiding dropdown menu (#2579)
 * Ensure build logs archive lookup URL checks build permissions (#2578)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-302[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-302[Link to this Release]
 
 [[rn-2-301]]
 == Version 2.3.1
@@ -63,7 +63,7 @@ Fixed:
 
 * Specify default server value for new bool field added to the repository table
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-301[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-301[Link to this Release]
 
 [[rn-2-300]]
 == Version 2.3.0
@@ -99,4 +99,4 @@ Fixed:
 * Backfill replication script when adjusting replication destinations (#2555)
 * Errors when deleting repositories without security scanning enabled (#2554)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-300[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-300[Link to this Release]

--- a/modules/rn_2_40.adoc
+++ b/modules/rn_2_40.adoc
@@ -28,4 +28,4 @@ Fixed:
 * Torrent validation in superuser config panel (#2694)
 * Expensive database call in build badges (#2688)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-400[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-400[Link to this Release]

--- a/modules/rn_2_50.adoc
+++ b/modules/rn_2_50.adoc
@@ -19,4 +19,4 @@ Fixed:
 * Setting of team resync option
 * Purge repository on very large repositories
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-500[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-500[Link to this Release]

--- a/modules/rn_2_60.adoc
+++ b/modules/rn_2_60.adoc
@@ -11,7 +11,7 @@ Fixed:
 
 * Failure to register uploaded TLS certificates (#2946)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-602[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-602[Link to this Release]
 
 [[rn-2-601]]
 == Version 2.6.1
@@ -31,7 +31,7 @@ Fixed:
 * Inability to display Tag Signing status (#2890)
 * Broken health check for OIDC authentication (#2888)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-601[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-601[Link to this Release]
 
 [[rn-2-600]]
 == Version 2.6.0
@@ -54,4 +54,4 @@ Fixed:
 * Lazy loading of teams and robots (#2883)
 * OIDC auth headers (#2695)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-600[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-600[Link to this Release]

--- a/modules/rn_2_70.adoc
+++ b/modules/rn_2_70.adoc
@@ -28,4 +28,4 @@ Fixed:
 * "Restart Container" button in superuser config panel (#2928)
 * Various small JavaScript security fixes
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-700[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-700[Link to this Release]

--- a/modules/rn_2_80.adoc
+++ b/modules/rn_2_80.adoc
@@ -28,4 +28,4 @@ Fixed:
 * Warning bar should not be displayed for already expired application tokens (#3003)
 
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-800[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-800[Link to this Release]

--- a/modules/rn_2_90.adoc
+++ b/modules/rn_2_90.adoc
@@ -10,7 +10,7 @@ Fixed:
 
 * Prohibit DES TLS ciphers
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-905[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-905[Link to this Release]
 
 [[rn-2-904]]
 == Version 2.9.4
@@ -20,7 +20,7 @@ Fixed:
 
 * Georeplication under certain failure conditions would incorrectly mark storage as replicated (#3283)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-904[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-904[Link to this Release]
 
 [[rn-2-903]]
 == Version 2.9.3
@@ -30,7 +30,7 @@ Fixed:
 
 * Changed to using v4 of Gitlab API now that v3 has been deprecated and removed (#3110)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-903[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-903[Link to this Release]
 
 [[rn-2-902]]
 == Version 2.9.2
@@ -62,7 +62,7 @@ Fixed:
 * Respect CPU affinity when determining number of workers to run (#3064)
 * Breakage in RECATPCHA support (#3065)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-902[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-902[Link to this Release]
 
 [[rn-2-901]]
 == Version 2.9.1
@@ -79,7 +79,7 @@ Fixed:
 * Specify default server value for new integer fields added (#3052)
 * Overflow of repository grid UI (#3049)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-901[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-901[Link to this Release]
 
 [[rn-2-900]]
 == Version 2.9.0
@@ -107,5 +107,5 @@ Fixed:
 * Squashed images with hard links pointing to deleted files no longer fail (#3032)
 * 500 error when trying to pull certain images via torrent (#3036)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-2-900[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-2-900[Link to this Release]
 

--- a/modules/rn_3_00.adoc
+++ b/modules/rn_3_00.adoc
@@ -12,7 +12,7 @@ Fixed:
 * Remove obsolete 01_copy_syslog_config.sh
 * Config tool fails to set up database when password string contains "$"
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-005[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-005[Link to this Release]
 
 [[rn-3-004]]
 == Version 3.0.4
@@ -27,7 +27,7 @@ Fixed:
 * nginx access and error logs now to stdout
 
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-004[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-004[Link to this Release]
 
 
 [[rn-3-003]]
@@ -41,7 +41,7 @@ Fixed:
 * Connection pooling was ignoring environment variable
 * Exception when in OAuth approval flow
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-003[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-003[Link to this Release]
 
 [[rn-3-002]]
 == Version 3.0.2
@@ -53,7 +53,7 @@ Fixed:
 * {productname}'s security scan endpoint is now enabled at startup for viewing results of Clair container image scans.
 * A flaw was found in the way the DES/3DES cipher was used as part of the TLS/SSL protocol. A man-in-the-middle attacker could use this flaw to recover some plaintext data by capturing large amounts of encrypted traffic between TLS/SSL server and client if the communication used a DES/3DES based ciphersuite. (CVE-2016-2183)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-002[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-002[Link to this Release]
 
 [[rn-3-001]]
 == Version 3.0.1
@@ -63,7 +63,7 @@ Fixed:
 
 * Health API endpoint (/health/instance) now correctly checks the internal port to verify all services.
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-001[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-001[Link to this Release]
 
 [[rn-3-000]]
 == Version 3.0.0
@@ -141,4 +141,4 @@ Previous versions of images required running in privileged mode. To remove this 
 The move to a RHEL base image means the certificate install path has changed to /etc/pki/ca-trust/source/anchors. Examples running the images have been updated to reflect this.
 
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-000[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-000[Link to this Release]

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -6,7 +6,7 @@ Fixed:
 
 * NVD stopped publishing the XML feed, Clair now consumes JSON feed
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-103[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-103[Link to this Release]
 
 [[rn-3-102]]
 == Version 3.1.2
@@ -21,7 +21,7 @@ Fixed:
 * Quay V3 upgrade fails with "id field missing from v1Compatibility JSON"
 * Security token for storage proxy properly URL encoded
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-102[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-102[Link to this Release]
 
 ifdef::downstream[]
 
@@ -38,7 +38,7 @@ Fixed:
 * Removed kernel-headers package from clair-jwt and quay-builder images to elliminate false vulnerabilities
 * Updated SCL rh-nginx112 (related to CVE-2019-9511, CVE-2019-9513, CVE-2019-9516)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-101[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-101[Link to this Release]
 
 [[rn-3-100]]
 == Version 3.1.0
@@ -69,8 +69,8 @@ Known Issues:
 
 * During repository mirroring, in order to fetch tags from a repository, at least
 one tag in the list of tags to sync must exist exactly as specified. See
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index#repo-mirroring-in-red-hat-quay[Repository Mirroring in Red Hat Quay] for more details.
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#repo-mirroring-in-red-hat-quay[Repository Mirroring in Red Hat Quay] for more details.
 * Repository mirror config has known issues when remote registry username or password has characters requiring special handling for shell commands. Specifically, the tokens for registry.redhat.io with a pipe (|) character in them are incorrectly escaped. Out of an abundance of caution, a fix for this will follow in a subsequent update.
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-100[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-100[Link to this Release]
 endif::downstream[]

--- a/modules/rn_3_20.adoc
+++ b/modules/rn_3_20.adoc
@@ -1,3 +1,15 @@
+[[rn-3-202]]
+== Version 3.2.2
+Release Date: April 27, 2020
+
+Fixed:
+
+* Clair correctly downloads vulnerabilities even if one fails
+(see link:https://issues.redhat.com/browse/PROJQUAY-567[PROJQUAY-567]).
+
+
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-202[Link to this Release]
+
 [[rn-3-201]]
 == Version 3.2.1
 Release Date: February 10, 2020
@@ -10,7 +22,7 @@ Fixed:
 * yarn: nodejs-yarn: Install functionality can be abused to generate arbitrary symlinks.
 (See link:https://access.redhat.com/security/cve/CVE-2019-10773[CVE-2019-10773].)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-201[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-201[Link to this Release]
 
 [[rn-3-200]]
 == Version 3.2.0
@@ -54,4 +66,4 @@ It is strongly suggested to have this flag enabled and to
 restrict access to V1 push.
 ```
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-3-200[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-3-200[Link to this Release]


### PR DESCRIPTION
Added release notes entry for 3.2.2. Updated attributes to add "producty" attribute, which allows the y-stream release number to be set and used in URLs to the docs.