### PR TITLE
Noted OCP 4.3 needed for CSO, per PROJQUAY-340

### DIFF
--- a/modules/proc_container-security-operator-setup.adoc
+++ b/modules/proc_container-security-operator-setup.adoc
@@ -3,7 +3,7 @@
 
 Using the link:https://operatorhub.io/operator/container-security-operator[Container Security Operator],
 (CSO) you can scan container images associated
-with active pods, running on OpenShift and other Kubernetes
+with active pods, running on OpenShift (4.3 or later) and other Kubernetes
 platforms, for known vulnerabilities. The CSO:
 
 * Watches containers associated with pods on all or specified namespaces


### PR DESCRIPTION
Noted that to use the Container Security Operator, OpenShift 4.3 or later is required. This is noted in PROJQUAY-340.