### PR TITLE
Added :Z to docker.sock mount per PROJQUAY-113

### DIFF
--- a/modules/proc_use-quay-build-workers-dockerfiles.adoc
+++ b/modules/proc_use-quay-build-workers-dockerfiles.adoc
@@ -80,7 +80,7 @@ ifdef::upstream[]
 # docker run --restart on-failure \
   -e SERVER=ws://myquayenterprise \
   --privileged=true \
-  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /var/run/docker.sock:/var/run/docker.sock:Z \
   <registry>/<repo>/quay-builder:{productminv}
 ....
 endif::upstream[]
@@ -91,7 +91,7 @@ ifdef::downstream[]
 # docker run --restart on-failure \
   -e SERVER=ws://myquayenterprise \
   --privileged=true \
-  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /var/run/docker.sock:/var/run/docker.sock:Z \
   {productrepo}/quay-builder:{productminv}
 ....
 endif::downstream[]
@@ -106,7 +106,7 @@ If {productname} is setup to use a SSL certificate that is not globally trusted,
   -e SERVER=wss://myquayenterprise \
   --privileged=true \
   -v /path/to/ssl/rootCA.pem:/etc/pki/ca-trust/source/anchors/rootCA.pem \
-  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /var/run/docker.sock:/var/run/docker.sock:Z \
   {productrepo}/quay-builder:{productminv}
 ....
 [[set-up-github-build]]


### PR DESCRIPTION
Updated the "docker run" command for running quay-builder to add :Z to the end of the mount of docker.sock within the container. This should cause SELinux file labeling to work properly on that item. The resulting fix will be published here: https://access.redhat.com/documentation/en-us/red_hat_quay/3.2/html-single/use_red_hat_quay/index#run-the-build-worker-image and on the 3.3 version as well.