### PR TITLE
Enhance phrasing on a single Quay Operator v3.3.0 release note

### DIFF
--- a/modules/rn_3_30.adoc
+++ b/modules/rn_3_30.adoc
@@ -68,7 +68,7 @@ Added:
 * The Quay Config App now continues running by default.
 * The Redis and Hostname configuration are marked "Read Only" in the Quay Configuration App.
 * Support for managing superusers.
-* Added support for injecting config files for Quay and Clair.
+* Add ability to inject certificates, and any other file, into the Quay and Clair secrets.
 * (OpenShift) SCC management refinement. Removal of SCCs when QuayEcosystem is deleted through the use of finalizers.
 * Certificates and other secrets are now mounted in a way that is compatible with Quay and Quay's Config App.
 * The operator now verifies the configuration for the Hostname, Redis, and Postgres when Quay's configuration secret is changed.


### PR DESCRIPTION
This clarifies a particular release note that was potentially misleading and found to be non-obvious to QE.