### PR TITLE
Final editing pass after publishing Quay 3.3

### DIFF
--- a/modules/con_schema.adoc
+++ b/modules/con_schema.adoc
@@ -157,7 +157,7 @@ All fields are optional unless otherwise marked.
 * **FEATURE_SECURITY_NOTIFICATIONS** [boolean]: If the security scanner is enabled, whether to turn on/off security notifications. Defaults to False.
 ** **Example**: `False`
 * **FEATURE_SECURITY_SCANNER** [boolean]: Whether to turn on/off the security scanner. Defaults to False.
-** **Reference**: https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#clair-initial-setup
+** **Reference**: https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#clair-initial-setup
 ** **Example**: `False`
 * **FEATURE_STORAGE_REPLICATION** [boolean]: Whether to automatically replicate between storage engines. Defaults to False.
 ** **Example**: `False`

--- a/modules/proc_deploy_quay_add.adoc
+++ b/modules/proc_deploy_quay_add.adoc
@@ -84,7 +84,7 @@ Setting up and deploying Clair image scanning for your
 * Deploying the Clair container
 
 These steps are described in
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index#quay-security-scanner[{productname} Security Scanning with Clair].
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#quay-security-scanner[{productname} Security Scanning with Clair].
 
 [[add-repo-mirroring]]
 == Add repository mirroring {productname}
@@ -99,7 +99,7 @@ To add the repository mirroring feature to your {productname} cluster:
 `repomirror` option.
 * Select "Enable Repository Mirroring in the {productname} Setup tool.
 * Log into your {productname} Web UI and begin creating mirrored repositories
-as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index[Repository Mirroring in Red Hat Quay].
+as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index[Repository Mirroring in Red Hat Quay].
 
 The following procedure assumes you already have a running
 {productname} cluster on an OpenShift platform, with the {productname} Setup
@@ -125,4 +125,4 @@ communications and verify certificates during mirroring, select this check box.
 image:repo_mirror_config.png[Enable mirroring and require HTTPS and verified certificates]
 . **Save configuration**: Select the Save Configuration Changes button. Repository
 mirroring should now be enabled on your {productname} cluster. Refer to
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index[Repository Mirroring in {productname}] for details on setting up your own mirrored container image repositories.
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index[Repository Mirroring in {productname}] for details on setting up your own mirrored container image repositories.

--- a/modules/proc_deploy_quay_guided.adoc
+++ b/modules/proc_deploy_quay_guided.adoc
@@ -86,7 +86,7 @@ as described at the end of this procedure.
 +
 **Here are the settings you need to consider:**
 +
-* **Custom SSL Certificates**: Upload custom or self-signed SSL certificates for use by {productname}. See link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}] for details. Recommended for high availability.
+* **Custom SSL Certificates**: Upload custom or self-signed SSL certificates for use by {productname}. See link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}] for details. Recommended for high availability.
 +
 [IMPORTANT]
 ====
@@ -118,7 +118,7 @@ you can have those logs directed to Elasticsearch for later search and analysis.
 To do this, change the value of Action Logs Storage to Elasticsearch and configure
 related settings as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#configure-action-log-storage[Configure action log storage].
 * **Action Log Rotation and Archiving**: Select to enable log rotation, which moves logs older than 30 days into storage, then indicate storage area.
-* **Security Scanner**: Enable security scanning by selecting a security scanner endpoint and authentication key. To setup Clair to do image scanning, refer to link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#clair-initial-setup[Clair Setup] and link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#configuring-clair-for-tls[Configuring Clair]. Recommended for high availability.
+* **Security Scanner**: Enable security scanning by selecting a security scanner endpoint and authentication key. To setup Clair to do image scanning, refer to link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#clair-initial-setup[Clair Setup] and link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#configuring-clair-for-tls[Configuring Clair]. Recommended for high availability.
 * **Application Registry**: Enable an additional application registry that includes things like Kubernetes manifests or Helm charts (see the link:https://github.com/app-registry[App Registry specification]).
 * **rkt Conversion**: Allow `rkt fetch` to be used to fetch images from {productname} registry. Public and private GPG2 keys are needed. This field is deprecated.
 * **E-mail**: Enable e-mail to use for notifications and user password resets.

--- a/modules/proc_deploy_quay_openshift.adoc
+++ b/modules/proc_deploy_quay_openshift.adoc
@@ -262,7 +262,7 @@ Select `Create Super User`, and proceed to the next screen.
 +
 Here are all the settings you need to consider:
 +
-- **Custom SSL Certificates**: Upload custom or self-signed SSL certificates for use by {productname}. See link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}] for details. Recommended for high availability.
+- **Custom SSL Certificates**: Upload custom or self-signed SSL certificates for use by {productname}. See link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}] for details. Recommended for high availability.
 +
 [IMPORTANT]
 ====
@@ -281,7 +281,7 @@ $ oc get route -n quay-enterprise quay-enterprise
 NAME            HOST/PORT                                                               PATH SERVICES                  PORT TERMINATION WILDCARD
 quay-enterprise quay-enterprise-quay-enterprise.apps.cnegus-ocp.devcluster.openshift.com     quay-enterprise-clusterip <all>            None
 ```
-See link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}]. TLS termination can be done in two different ways:
+See link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#using-ssl-to-protect-quay[Using SSL to protect connections to {productname}]. TLS termination can be done in two different ways:
   ** On the instance itself, with all TLS traffic governed by the nginx server in the quay container (recommended).
   ** On the load balancer. This is not recommended. Access to {productname} could be lost if the TLS setup is not done correctly on the load balancer.
 
@@ -459,7 +459,7 @@ and fill in the clair-service endpoint. For example, http://clair-service:6060
 A green check mark will appear on the screen when the deployment is done.
 You can now start using Clair image scanning with {productname}.
 For information on the data sources available with the Clair image scanner, see
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/clair-initial-setup#clair-sources[Using Clair data sources].
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html/manage_red_hat_quay/clair-initial-setup#clair-sources[Using Clair data sources].
 
 [[add-repo-mirroring]]
 == Add repository mirroring {productname}
@@ -474,7 +474,7 @@ To add the repository mirroring feature to your {productname} cluster:
 `repomirror` option.
 * Select "Enable Repository Mirroring in the {productname} Setup tool.
 * Log into your {productname} Web UI and begin creating mirrored repositories
-as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index[Repository Mirroring in Red Hat Quay].
+as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index[Repository Mirroring in Red Hat Quay].
 
 The following procedure assumes you already have a running
 {productname} cluster on an OpenShift platform, with the {productname} Setup
@@ -502,7 +502,7 @@ communications and verify certificates during mirroring, select this check box.
 image:repo_mirror_config.png[Enable mirroring and require HTTPS and verified certificates]
 . **Save configuration**: Select the Save Configuration Changes button. Repository
 mirroring should now be enabled on your {productname} cluster. Refer to
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/index[Repository Mirroring in {productname}] for details on setting up your own mirrored container image repositories.
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index[Repository Mirroring in {productname}] for details on setting up your own mirrored container image repositories.
 [NOTE]
 ====
 The server hostname you set with the config tools may not represent and endpoint

--- a/modules/proc_manage-clair-enable.adoc
+++ b/modules/proc_manage-clair-enable.adoc
@@ -13,7 +13,7 @@ directly on a host.
 == Run Clair on a {productname} OpenShift deployment
 To run the Clair image scanning container and its associated database on an OpenShift environment with your
 {productname} cluster, see 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_on_openshift/index#add_clair_scanner[Add Clair image scanning to {productname}].
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_on_openshift/index#add_clair_scanner[Add Clair image scanning to {productname}].
 
 
 == Run Clair on a {productname} Basic or HA deployment
@@ -81,7 +81,7 @@ in an auto-scaling group with automatic healing.
 
 . Create a `config.yaml` file to be used in the Clair config directory (`/clair/config`) from one of the two Clair configuration files shown here.
 . If you are doing a high-availability installation, go through the procedure in
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#authentication-for-high-availability-scanners[Authentication for high-availability scanners] to create a Key ID and Private Key (PEM).
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#authentication-for-high-availability-scanners[Authentication for high-availability scanners] to create a Key ID and Private Key (PEM).
 . Save the Private Key (PEM) to a file (such as, $HOME/config/security_scanner.pem).
 . Replace the value of key_id (CLAIR_SERVICE_KEY_ID) with the Key ID you generated and
 the value of private_key_path with the location of the PEM file (for example, /config/security_scanner.pem).
@@ -284,7 +284,7 @@ it below.
 ==== Configuring trust of self-signed SSL
 
 Similar to the process for setting up Docker to
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#configuring-docker-to-trust-a-certificate-authority[trust
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#configuring-docker-to-trust-a-certificate-authority[trust
 your self-signed certificates], Clair must also be configured to trust
 your certificates. Using the same CA certificate bundle used to
 configure Docker, complete the following steps:

--- a/modules/proc_manage-clairv4.adoc
+++ b/modules/proc_manage-clairv4.adoc
@@ -8,6 +8,9 @@ which means that it is not supported for production use. However, you are
 encouraged to test Clair v4 as it represents the direction of Clair image scanning
 development.
 
+To align with the {productname} release, the current Clair v4 release image
+is clair:{productminv}.
+
 == What is Clair v4?
 
 Technically, Clair v4 is a set of micro services that can be used with {productname}
@@ -138,7 +141,7 @@ $ oc create -n $namespace -f ./clairv4-postgres.yaml
 . Create the Clair v4 deployment file (for example, `clair-combo.yaml`) and modify it as necessary:
 +
 .clair-combo.yaml
-[source,yaml]
+[source,yaml,subs="verbatim,attributes"]
 ----
 ---
 apiVersion: extensions/v1beta1

--- a/modules/proc_manage-ldap-setup.adoc
+++ b/modules/proc_manage-ldap-setup.adoc
@@ -15,7 +15,6 @@ configuring the LDAP Setup already exist in the LDAP directory. Before attemptin
 the setup, make sure that you are logged in as a superuser that matches
 user credentials in LDAP. In order to do so, Navigate to the SuperUser
 panel (ex: http(s)://quay.enterprise/superuser) and click on the “Create
-
 User” button to create a new User. Make sure to create a user that
 matches the username/email syntax in LDAP.
 

--- a/modules/proc_manage-quay-geo-replication.adoc
+++ b/modules/proc_manage-quay-geo-replication.adoc
@@ -26,16 +26,14 @@ time.
 ====
 
 [id='visit-the-management-panel_{context}']
-== Visit the Management Panel
+== Visit the Config Tool
 
-Sign in to a superuser account from the {productname} login screen. For
-example, if the host were reg.example.com, you would go to `http://reg.example.com/superuser` to view the management panel:
-image:superuser.png[Log in as superuser to set up Georeplication]
+Open the {productname} Config Tool to configure storage for georeplication.
 
 [[enable-storage-replication]]
 == Enable storage replication
 
-.  Click the configuration tab and scroll down to the section
+.  Scroll down to the section
 entitled `Registry Storage`.
 .  Click `Enable Storage Replication`.
 .  Add each of the storage engines to which data will be replicated.
@@ -45,7 +43,8 @@ required, under each storage engine configuration click `Replicate to
 storage engine by default`. This will ensure that all images are
 replicated to that storage engine. To instead enable per-namespace
 replication, please contact support.
-.  Click Save to validate.
+.  When you are done, click `Save Configuration Changes`.
+Configuration changes will take effect the next time {productname} restarts.
 
 .  After adding storage and enabling “Replicate to storage engine by default” for Georeplications, you need to sync existing image data across all storage.
 To do this, you need to `oc exec` (or docker/kubectl exec) into the container

--- a/modules/proc_manage-quay-ssl.adoc
+++ b/modules/proc_manage-quay-ssl.adoc
@@ -1,11 +1,11 @@
 [[using-ssl-to-protect-quay]]
 = Using SSL to protect connections to {productname}
 
-This document assumes you have deployed {productname} in a link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/getting_started_with_red_hat_quay/[single-node] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_-_high_availability[highly available] deployment.
+This document assumes you have deployed {productname} in a link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/getting_started_with_red_hat_quay/[single-node] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_-_high_availability[highly available] deployment.
 
 To configure {productname} with a
 https://en.wikipedia.org/wiki/Self-signed_certificate[self-signed
-certificate], you need to create a Certificate Authority (CA), then generate the required key and certificate files. You then enter those files using the {productname} superuser GUI or command line.
+certificate], you need to create a Certificate Authority (CA), then generate the required key and certificate files. You then enter those files using the {productname} Config Tool or command line.
 
 [[create-a-ca-and-sign-a-certificate]]
 == Create a CA and sign a certificate

--- a/modules/proc_manage-repomirror.adoc
+++ b/modules/proc_manage-repomirror.adoc
@@ -67,9 +67,9 @@ Before you can use repository mirroring, you must enable repository mirroring fr
 configuration screen and start the repository mirroring worker. Ways of starting up this service are described
 in the {productname} deployment guides:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_-_basic/index[Deploy {productname} - Basic]
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_-_high_availability/index[Deploy {productname} - High Availability]
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_on_openshift/index[Deploy {productname} on OpenShift]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_-_basic/index[Deploy {productname} - Basic]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_-_high_availability/index[Deploy {productname} - High Availability]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_on_openshift/index[Deploy {productname} on OpenShift]
 
 The steps shown in the following section assumes you already have the repository mirroring service running and
 that you have enabled repository mirroring on your {productname} cluster.

--- a/modules/proc_manage-security-scanning.adoc
+++ b/modules/proc_manage-security-scanning.adoc
@@ -18,7 +18,7 @@ start the config tool for that environment.
 The procedure varies, based on whether you are running {productname} on OpenShift or directly on a host.
 
 === Enabling Clair on a {productname} OpenShift deployment
-To set up Clair on {productname} in OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_on_openshift/index#add-clair-scanner[Add Clair image scanning to {productname}].
+To set up Clair on {productname} in OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/deploy_red_hat_quay_on_openshift/index#add-clair-scanner[Add Clair image scanning to {productname}].
 
 === Enabling Clair on a {productname} Basic or HA deployment
 To set up Clair on a {productname} deployment where the container is running directly on the host system, do the following:

--- a/modules/proc_manage-upgrade-quay-guide.adoc
+++ b/modules/proc_manage-upgrade-quay-guide.adoc
@@ -9,7 +9,7 @@ This document describes how to upgrade one or more Quay containers.
 The database is the "source of truth" for Quay, and some version
 upgrades will trigger a schema update and data migration. Such versions
 are clearly documented in the
-https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes].
+https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes].
 
 Backup the database before upgrading Quay. Once the backup
 completes, use the procedure in this document to stop the running Quay container, start the new container, and check the health of

--- a/modules/proc_manage-upgrade-quay.adoc
+++ b/modules/proc_manage-upgrade-quay.adoc
@@ -2,7 +2,7 @@
 = Upgrading Quay
 
 The full list of Quay versions can be found on the
-https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes]
+https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes]
 page.
 
 [[special-note-upgrading-from-quay-enterprise-2.0.0-to-2.0.0]]
@@ -11,7 +11,7 @@ page.
 ====
 If you are upgrading from a version of Quay older than 2.0.0,
 you *must* upgrade to Quay 2.0.0 *first*. Please follow the
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/manage_red_hat_quay/#upgrade-to-quay-2.0.0[Upgrade to Quay 2.0.0 instructions]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/manage_red_hat_quay/#upgrade-to-quay-2.0.0[Upgrade to Quay 2.0.0 instructions]
 to upgrade to Quay 2.0.0, and then follow the instructions
 below to upgrade from 2.0.0 to the latest version you'd like.
 ====
@@ -28,7 +28,7 @@ release.
 [[the-upgrade-process]]
 == The upgrade process
 
-.  Visit the https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes] page and note the latest version of Quay.
+.  Visit the https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes/[Red Hat Quay Release Notes] page and note the latest version of Quay.
 .  Shutdown the Quay cluster: Remove *all* containers from
 service.
 .  On a *single* node, run the newer version of Quay.

--- a/modules/proc_use-quay-tags.adoc
+++ b/modules/proc_use-quay-tags.adoc
@@ -102,7 +102,7 @@ The value of Time Machine (in User settings) defines when the deleted tag is act
 and garbage collected. By default, that value is 14 days. Up until that time, a tag can be repointed to an expired or deleted image.
 
 * The {productname} superuser has no special privilege related to deleting expired images from user repositories.
-There is no central machanism for the superuser to gather information and act on user repositories.
+There is no central mechanism for the superuser to gather information and act on user repositories.
 It is up to the owners of each repository to manage expiration and ultimate deletion of their images.
 
 Tag expiration can be set in different ways:

--- a/modules/rn_1_13.adoc
+++ b/modules/rn_1_13.adoc
@@ -65,4 +65,4 @@ Release Date: November 2, 2015
 * Improved internal test suite (#470, #511, #526, #514, #545, #570, #572, #573, #583, #711, #728, #730)
 * Improved background worker stability (#471)
 
-link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_release_notes#rn-1-130[Link to this Release]
+link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_release_notes#rn-1-130[Link to this Release]


### PR DESCRIPTION
I fixed a bunch of small issues after doing a final read-through of the Red Hat Quay 3.3 docs. These includes some broken links, typos, and old references to the previous superuser panel. 