### PR TITLE
OpenShift Route Limitations with Builders (PROJQUAY-1418)

### DIFF
--- a/modules/proc_use-quay-build-workers-dockerfiles.adoc
+++ b/modules/proc_use-quay-build-workers-dockerfiles.adoc
@@ -27,7 +27,7 @@ The orchestrator is used to store the state of currently running build jobs, and
 
 [[openshift-requirements]]
 == OpenShift Requirements
-{productname} builds are supported on K8s and OpenShift 4.5 and higher.  A bare metal (non-virtualized) worker node is required since build pods require the ability to run kvm virtualization.  Each build is done in an ephemeral virtual machine to ensure complete isolation and security while the build is running.  In addition, your OpenShift cluster should permit the ServiceAccount associated with {productname} builds to run with the necessary SecurityContextConstraint to support privileged containers.
+{productname} builds are supported on Kubernetes and OpenShift 4.5 and higher.  A bare metal (non-virtualized) worker node is required since build pods require the ability to run kvm virtualization.  Each build is done in an ephemeral virtual machine to ensure complete isolation and security while the build is running.  In addition, your OpenShift cluster should permit the ServiceAccount associated with {productname} builds to run with the necessary SecurityContextConstraint to support privileged containers.
 
 
 [[orchestrator-requirements]]
@@ -48,16 +48,16 @@ There are several actions that are needed on an OpenShift cluster before it can 
 $ oc create project builder
 ```
 +
-. Create a ServiceAccount in this Project that will be used to run builds.  Ensure it has sufficient privileges to create Jobs and Pods.  Copy the ServiceAccount’s token for use later.
+. Create a `ServiceAccount` in this `Project` that will be used to run builds.  Ensure it has sufficient privileges to create `Jobs` and `Pods`.  Copy the `ServiceAccount`’s token for use later.
 +
 ```
-$ oc create sa quay-builder
-$ oc policy add-role-to-user edit system:serviceaccount:builder:quay-builder
-$ oc sa get-token quay-builder
+$ oc create sa -n builder quay-builder
+$ oc policy add-role-to-user -n builder edit system:serviceaccount:builder:quay-builder
+$ oc sa get-token -n builder quay-builder
 ```
 +
 . Identify the URL for the OpenShift cluster’s API server.  This can be found from the OpenShift Console.
-. Identify a Worker node label to be used when scheduling Build Jobs.  Because build pods need to run on baremetal worker nodes, typically these are identified withi specific labels.  Check with your cluster administrator to determine exactl which node label should be used.
+. Identify a worker node label to be used when scheduling build `Jobs`.  Because build pods need to run on baremetal worker nodes, typically these are identified withi specific labels.  Check with your cluster administrator to determine exactly which node label should be used.
 . If the cluster is using a self-signed certificate, get the kube apiserver’s CA to add to {productname}’s extra certs.
 .. Get the name of the secret containing the CA:
 +
@@ -67,13 +67,13 @@ $ oc get sa openshift-apiserver-sa --namespace=openshift-apiserver -o json | jq 
 +
 .. Get the `ca.crt` key value from the secret in the Openshift console. The value should begin with “-----BEGIN CERTIFICATE-----”
 .. Import the CA in {productname} using the ConfigTool
-. Create the necessary security contexts/role bindings for the cluster/service account:
+. Create the necessary security contexts/role bindings for the `ServiceAccount`:
 [source,yaml]
 ----
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: quay-builder-scc
+  name: quay-builder
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
@@ -106,11 +106,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: quay-builder-scc
+  namespace: builder
 rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - quay-builder-scc
+  - quay-builder
   resources:
   - securitycontextconstraints
   verbs:
@@ -119,7 +120,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: quay-builder-scc-role-binding
+  name: quay-builder-scc
+  namespace: builder
 subjects:
 - kind: ServiceAccount
   name: quay-builder
@@ -131,12 +133,12 @@ roleRef:
 
 === Enable Builders and add Build Configuration to {productname}’s Configuration Bundle
 
-. Ensure that you’ve got Builds enabled in your {productname} Configuration.
+. Ensure that you’ve got Builds enabled in your {productname} configuration.
 [source,yaml]
 ----
 FEATURE_BUILD_SUPPORT: True
 ----
-. Add the following to your {productname} Configuration Bundle, replacing each value with a value specific to your installation.
+. Add the following to your {productname} configuration bundle, replacing each value with a value specific to your installation.
 
 [NOTE]
 ====
@@ -268,6 +270,31 @@ AWS builds are not supported by Red Hat and are currently provided as an upstrea
 
 endif::upstream[]
 
+== OpenShift Routes Limitation
+
+[NOTE]
+====
+This section only applies if you are using the Quay Operator on OpenShift with managed `route` component.
+====
+
+Due to a limitation of OpenShift `Routes` to only be able to serve traffic to a single port, additional steps are required to set up builds. Ensure your `kubectl`/`oc` CLI tool is configured to work with the cluster which the Quay Operator is installed and your `QuayRegistry` exists (not necessarily the same as the bare-metal cluster where your builders run).
+
+* Ensure that HTTP/2 ingress is enabled on the OpenShift cluster by following link:https://docs.openshift.com/container-platform/4.5/networking/ingress-operator.html#nw-http2-haproxy_configuring-ingress[these steps].
+
+* The Quay Operator will create a `Route` which directs gRPC traffic to the build manager server running inside the existing Quay pod(s). If you want to use a custom hostname (such as a subdomain like `builder.registry.example.com`), ensure that you create a CNAME record with your DNS provider which points to the `status.ingress[0].host` of the created `Route`:
+----
+$ kubectl get -n <namespace> route <quayregistry-name>-quay-builder -o jsonpath={.status.ingress[0].host}
+----
+
+* Using the OpenShift UI or CLI, update the `config.yaml` entry of the `Secret` referenced by `spec.configBundleSecret` of the `QuayRegistry` with the correct values referenced in the builder config above (depending on your build executor ) and also add the following fields:
+[source,yaml]
+----
+  BUILDMAN_HOSTNAME: <build-manager-hostname>
+----
+
+Each configuration field is explained below:
+
+BUILDMAN_HOSTNAME:: The externally accessible server hostname which the build jobs use to communicate back to the build manager. Default is the same as `SERVER_HOSTNAME`. For OpenShift `Route`, it is either `status.ingress[0].host` or the CNAME entry if using a custom hostname.
 
 == Troubleshooting Builds
 The builder instances started by the build manager are ephemeral. This means that they will either get shut down by {productname}} on timeouts/failure or garbaged collected by the control plane (EC2/K8s). This means that in order to get the builder logs, one needs to do so **while** the builds are running.


### PR DESCRIPTION
Adds the workaround to the limitation that OpenShift `Routes` cannot serve more than one port, so a second `Route` must be created to serve traffic to the build manager on the gRPC port.