### PR TITLE
Document Adding Build Cluster Certs to `configBundleSecret`

### DIFF
--- a/modules/proc_use-quay-build-workers-dockerfiles.adoc
+++ b/modules/proc_use-quay-build-workers-dockerfiles.adoc
@@ -286,7 +286,7 @@ Due to a limitation of OpenShift `Routes` to only be able to serve traffic to a 
 $ kubectl get -n <namespace> route <quayregistry-name>-quay-builder -o jsonpath={.status.ingress[0].host}
 ----
 
-* Using the OpenShift UI or CLI, update the `config.yaml` entry of the `Secret` referenced by `spec.configBundleSecret` of the `QuayRegistry` with the correct values referenced in the builder config above (depending on your build executor ) and also add the following fields:
+* Using the OpenShift UI or CLI, update the `Secret` referenced by `spec.configBundleSecret` of the `QuayRegistry` with the build cluster CA certificate (name the key `extra_ca_cert_build_cluster.cert`), and update the `config.yaml` entry with the correct values referenced in the builder config above (depending on your build executor) along with following fields:
 [source,yaml]
 ----
   BUILDMAN_HOSTNAME: <build-manager-hostname>


### PR DESCRIPTION
We forgot to add it to the Quay Operator section.