### PR TITLE
Removed "database" from subheading in Redis section

### DIFF
--- a/modules/proc_deploy_quay_poc_redis.adoc
+++ b/modules/proc_deploy_quay_poc_redis.adoc
@@ -15,7 +15,7 @@ $ sudo podman run -d --rm --name redis \
 ....
 
 
-== Determine the IP address of the database server 
+== Determine the IP address of the Redis server
 
 Use the `podman inspect` command to determine the IP address for Redis. You will need this information when using the configuration editor later.
 


### PR DESCRIPTION
This is a very minor change, the original seems to be copied from the db section above.