### PR TITLE
Remove Need for SANs in Operator Deployed Quay (PROJQUAY-1737)

### DIFF
--- a/modules/proc_deploy-quay-openshift-operator-tng-advanced.adoc
+++ b/modules/proc_deploy-quay-openshift-operator-tng-advanced.adoc
@@ -10,7 +10,7 @@ Once deployed, the Quay application itself can be configured as normal using the
 
 === Customizing External Access to the Registry
 
-When running on OpenShift, the `Routes` API is available and will automatically be used as a managed component. After creating the QuayRegistry, the external access point can be found in the status block of the `QuayRegistry`:
+When running on OpenShift, the `Routes` API is available and will automatically be used as a managed component. After creating the `QuayRegistry`, the external access point can be found in the status block of the `QuayRegistry`:
 
 [source,yaml]
 ----
@@ -18,27 +18,21 @@ status:
   registryEndpoint: some-quay.my-namespace.apps.mycluster.com
 ----
 
-The Operator creates a Service of `type: Loadbalancer` for your registry.  You can configure your DNS provider to point the `SERVER_HOSTNAME` to the external IP address of the service.
+When running on native Kubernetes, the Operator creates a Service of `type: ClusterIP` for your registry. You are then responsible for external access (like `Ingress`).
 
 ```
-$ oc get services -n <namespace>
+$ kubectl get services -n <namespace>
 NAME                    TYPE        CLUSTER-IP       EXTERNAL-IP          PORT(S)             AGE
-some-quay               ClusterIP   172.30.143.199   34.123.133.39        443/TCP,9091/TCP    23h
+some-quay               ClusterIP   172.30.143.199   <none>               443/TCP,9091/TCP    23h
 ```
 
 ==== Using a Custom Hostname and TLS
 
-By default, a `Route` will be created with the default generated hostname and a certificate/key pair will be generated for TLS.  If you want to access {productname} using a custom hostname and bring your own TLS certificate/key pair, follow these steps.
+By default, a `Route` will be created with the default generated hostname and a certificate/key pair will be generated for TLS. If you want to access {productname} using a custom hostname and bring your own TLS certificate/key pair, follow these steps.
 
-Because Quay will use TLS for in-cluster communication with other services within Kubernetes (like Clair), you must ensure that the certificate/key pair you use has Subject Alternative Names (SANs) for each of the following hostname patterns:
+If `FEATURE_BUILD_SUPPORT: true`, then make sure the certificate/key pair is also valid for the `BUILDMAN_HOSTNAME`.
 
-- `<quayregistry-name>-quay-app`
-- `<quayregistry-name>-quay-app.<quayregistry-namespace>.svc`
-- `<quayregistry-name>-quay-app.<quayregistry-namespace>.svc.cluster.local`
-
-If `FEATURE_BUILD_SUPPORT: true`, then make sure the certificate/key pair also includes `BUILDMAN_HOSTNAME`.
-
-If all of the above hostnames are not included as SANs, then the Quay Operator will reject your provided certificate/key pair and generate one to be used by {productname}.
+If the given cert/key pair is invalid for the above hostnames, then the Quay Operator will reject your provided certificate/key pair and generate one to be used by {productname}.
 
 Next, create a `Secret` with the following content:
 
@@ -66,6 +60,61 @@ spec:
   configBundleSecret: my-config-bundle
 ----
 
+==== Using OpenShift Provided TLS Certificate 
+
+It is preferred to have TLS terminated in the Quay app container. Therefore, to use the OpenShift provided TLS, you must create a `Route` with type "reencrypt", which will use the OpenShift provided TLS at the edge, and Quay Operator-generated TLS within the cluster. This is achieved by marking the `route` component as unmanaged, and creating your own `Route` which link:https://docs.openshift.com/container-platform/4.7/networking/routes/secured-routes.html[reencrypts TLS] using the Operator-generated CA certificate.
+
+Create a `Secret` with a `config.yaml` key containing the `SERVER_HOSTNAME` field of value `<route-name>-<namespace>.apps.<cluster-domain>` (the `Route` with this hostname will be created in a later step).
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-config-bundle
+data:
+  config.yaml: <must include SERVER_HOSTNAME field with your custom hostname>
+----
+
+Create a `QuayRegistry` referencing the above `Secret` and with the `route` component unmanaged:
+
+[source,yaml]
+----
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: some-quay
+spec:
+  configBundleSecret: my-config-bundle
+  components:
+  - kind: route
+    managed: false
+----
+
+Wait for the `QuayRegistry` to be fully reconciled by the Quay Operator. Then, acquire the generated TLS certificate by finding the `Secret` being mounted into the Quay app pods and copying the `tls.cert` value.
+
+Create a `Route` with TLS reencryption and the destination CA certificate you copied above:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: registry
+  namespace: <namespace>
+spec:
+  to: 
+    kind: Service
+    name: <quay-service-name>
+  tls:
+    termination: reencrypt
+    destinationCACertificate:
+      -----BEGIN CERTIFICATE-----
+      [...]
+      -----END CERTIFICATE-----
+----
+
+You can now access your Quay registry using the created `Route`.
 
 === Disabling Route Component
 


### PR DESCRIPTION
It is [no longer necessary](https://github.com/quay/quay-operator/pull/406) to include the internal Kubernetes hostnames as SANs of the provided cert/key pair (which was impossible using PKI).