### PR TITLE
Fixes Prometheus endpoint port in 3.4

### DIFF
--- a/modules/proc_manage-quay-prometheus.adoc
+++ b/modules/proc_manage-quay-prometheus.adoc
@@ -10,7 +10,7 @@ endpoint on each instance to allow for easy monitoring and alerting.
 
 The Prometheus- and
 Grafana-compatible endpoint on the {productname} instance can
-be found at port `9092`. See https://access.redhat.com/solutions/3750281[Monitoring Quay with Prometheus and Grafana] for details on configuring Prometheus
+be found at port `9091`. See https://access.redhat.com/solutions/3750281[Monitoring Quay with Prometheus and Grafana] for details on configuring Prometheus
 and Grafana to monitor Quay repository counts.
 
 [[setting-up-prometheus-to-consume-metrics]]


### PR DESCRIPTION
Cherry-picked from https://github.com/quay/quay-docs/pull/243 for https://issues.redhat.com/browse/PROJQUAY-2475. 