### PR TITLE
welcome: update getting started links to reflect changes on Quay repo (PROJQUAY-2500)

### DIFF
--- a/welcome.adoc
+++ b/welcome.adoc
@@ -8,9 +8,9 @@ Project Quay releases can be found on https://github.com/quay/quay/releases[gith
 
 == Getting Started
 
-Looking to try out Quay?  Please review our https://github.com/quay/quay/blob/master/docs/getting_started.md[Getting Started Guide].
+Looking to try out Quay? Please review our https://github.com/quay/quay/blob/master/docs/quick-local-deployment.md[Getting Started Guide].
 
-To create a development container, please see https://github.com/quay/quay/blob/master/docs/development-container.md[Setting Up A Quay Development Container].
+If you want to develop Quay, please see https://github.com/quay/quay/blob/master/docs/getting-started.md#running-quay-for-development[Getting Started For Development Guide].
 
 == Deploying Quay
 


### PR DESCRIPTION
❗ IMPORTANT: this needs to go in along with https://github.com/quay/quay/pull/884 so we avoid broken links in our docs.

Update links and wording of getting started for both evaluation and development docs on Github.