### PR TITLE
Amended component type storage to be object storage as thats the corr…

### DIFF
--- a/modules/operator-preconfigure.adoc
+++ b/modules/operator-preconfigure.adoc
@@ -1,7 +1,7 @@
 [[operator-preconfigure]]
 = Configuring Quay before deployment
 
-The Operator can manage all the {productname} components when deploying on OpenShift, and this is the default configuration. Alternatively, you can manage one or more components externally yourself, where you want more control over the set up, and then allow the Operator to manage the remaining components. 
+The Operator can manage all the {productname} components when deploying on OpenShift, and this is the default configuration. Alternatively, you can manage one or more components externally yourself, where you want more control over the set up, and then allow the Operator to manage the remaining components.
 
 The standard pattern for configuring unmanaged components is:
 
@@ -24,11 +24,11 @@ metadata:
 spec:
   configBundleSecret: config-bundle-secret
   components:
-    - kind: storage
+    - kind: objectstorage
       managed: false
 ----
 . Deploy the registry using the YAML file:
 +
 ----
-oc create -f quayregistry.yaml 
+oc create -f quayregistry.yaml
 ----


### PR DESCRIPTION
Minor document update. I was just following these docs to set external storage and I noticed that the component storage is actually supposed to be objectstorage. The operator was failing with a unknown component storage error when following the docs verbatim. 

@gabriel-rh - can you please review? 