### PR TITLE
Update haproxy config to use port 6379 for redis

### DIFF
--- a/modules/proc_deploy_quay_ha_lbdb.adoc
+++ b/modules/proc_deploy_quay_ha_lbdb.adoc
@@ -82,9 +82,9 @@ backend be_rdgw
     server ceph02 ceph02:7480 check
     server ceph03 ceph03:7480 check
 backend be_redis
-server quay01 quay01:6380 check inter 1s
-server quay02 quay02:6380 check inter 1s
-server quay03 quay03:6380 check inter 1s
+server quay01 quay01:6379 check inter 1s
+server quay02 quay02:6379 check inter 1s
+server quay03 quay03:6379 check inter 1s
 ```
 
 +

--- a/resources/haproxy_cfg.j2
+++ b/resources/haproxy_cfg.j2
@@ -90,4 +90,4 @@ backend be_redis
     tcp-check expect string role:master
     tcp-check send QUIT\r\n
     tcp-check expect string +OK
-    server redis_{{item}} {{item}}:6380 check inter 1s
+    server redis_{{item}} {{item}}:6379 check inter 1s

--- a/resources/quaylab.yml
+++ b/resources/quaylab.yml
@@ -217,7 +217,7 @@
       detach: yes
       restart_policy: always
       ports: 
-      - "6380:6379"
+      - "6379:6379"
 
   - name: Ensure root has a .docker directory
     file:


### PR DESCRIPTION
The haproxy config for deploying Quay in HA mode has redis on port 6380 in the backend while the redis deployment steps have redis on port 6379 here:

```
# mkdir -p /var/lib/redis
# chmod 777 /var/lib/redis
# sudo podman run -d -p 6379:6379 \
    -v /var/lib/redis:/var/lib/redis/data:Z \
    registry.redhat.io/rhel8/redis-5
```

This PR aligns the haproxy config in the documentation with the redis deployment steps as well as the testing resource haproxy config and ansible deployment file.