### PR TITLE
Adds backup and restore for standalone

### DIFF
--- a/manage_quay/master.adoc
+++ b/manage_quay/master.adoc
@@ -138,11 +138,15 @@ include::modules/georepl-deploy-operator.adoc[leveloffset=+3]
 include::modules/georepl-mixed-storage.adoc[leveloffset=+3]
 
 include::modules/backing-up-and-restoring-intro.adoc[leveloffset=+1]
-include::modules/backing-up-red-hat-quay.adoc[leveloffset=+2]
+include::modules/backing-up-red-hat-quay-operator.adoc[leveloffset=+2]
 include::modules/restoring-red-hat-quay.adoc[leveloffset=+2]
 
 
 include::modules/standalone-to-operator-backup-restore.adoc[leveloffset=+1]
+
+include::modules/standalone-deployment-backup-restore.adoc[leveloffset=+1]
+include::modules/backing-up-red-hat-quay-standalone.adoc[leveloffset=+2]
+include::modules/restoring-red-hat-quay-standalone.adoc[leveloffset=+2]
 
 include::modules/garbage-collection.adoc[leveloffset=+1]
 

--- a/modules/backing-up-red-hat-quay-operator.adoc
+++ b/modules/backing-up-red-hat-quay-operator.adoc
@@ -1,4 +1,4 @@
-[[backing-up-red-hat-quay]]
+[[backing-up-red-hat-quay-operator]]
 = Backing up {productname}
 
 This procedure describes how to create a backup of {productname} deployed on OpenShift Container Platform using the {productname} Operator

--- a/modules/backing-up-red-hat-quay-standalone.adoc
+++ b/modules/backing-up-red-hat-quay-standalone.adoc
@@ -1,0 +1,137 @@
+:_content-type: PROCEDURE
+[[backing-up-red-hat-quay-standalone]]
+= Backing up {productname} on standalone deployments 
+
+This procedure describes how to create a backup of {productname} on standalone deployments. 
+
+.Prerequisites
+
+.Procedure 
+
+. Create a temporary backup directory, for example, `quay-backup`: 
++
+[source,terminal]
+----
+$ mkdir /tmp/quay-backup
+----
+
+. The following example command denotes the local directory that the {productname} was started in, for example, `/opt/quay-install`: 
++
+[source,terminal]
+----
+$ podman run --name quay-app \
+   -v /opt/quay-install/config:/conf/stack:Z \
+   -v /opt/quay-install/storage:/datastorage:Z \
+   {productrepo}/{quayimage}:{productminv}
+----
++
+Change into the directory that bind-mounts to `/conf/stack` inside of the container, for example, `/opt/quay-install`, by running the following command: 
++
+[source,terminal]
+----
+$ cd /opt/quay-install
+----
+
+. Compress the contents of your {productname} deployment into an archive in the `quay-backup` directory by entering the following command: 
++
+[source,terminal]
+----
+$ tar cvf /tmp/quay-backup/quay-backup.tar.gz *
+----
++
+Example output:
++
+[source,terminal]
+----
+config.yaml
+config.yaml.bak
+extra_ca_certs/
+extra_ca_certs/ca.crt
+ssl.cert
+ssl.key
+----
+
+. Back up the Quay container service by entering the following command: 
++
+[source,terminal]
+----
+$ podman inspect quay-app | jq -r '.[0].Config.CreateCommand | .[]' | paste -s -d ' ' -
+
+  /usr/bin/podman run --name quay-app \
+  -v /opt/quay-install/config:/conf/stack:Z \
+  -v /opt/quay-install/storage:/datastorage:Z \
+  {productrepo}/{quayimage}:{productminv}
+----
+
+. Redirect the contents of your `conf/stack/config.yaml` file to your temporary `quay-config.yaml` file by entering the following command: 
++
+[source,terminal]
+----
+$ podman exec -it quay cat /conf/stack/config.yaml > /tmp/quay-backup/quay-config.yaml 
+----
+
+. Obtain the `DB_URI` located in your temporary `quay-config.yaml` by entering the following command:
++
+[source,terminal]
+----
+$ grep DB_URI /tmp/quay-backup/quay-config.yaml
+----
++
+Example output:
++
+----
+$ postgresql://<username>:test123@172.24.10.50/quay
+----
+
+. Extract the PostgreSQL contents to your temporary backup directory in a backup .sql file by entering the following command:
++
+[source,terminal]
+----
+$ pg_dump -h 172.24.10.50  -p 5432 -d quay  -U  <username>   -W -O > /tmp/quay-backup/quay-backup.sql
+----
+
+. Print the contents of your `DISTRIBUTED_STORAGE_CONFIG` by entering the following command: 
++
+[source,yaml]
+----
+DISTRIBUTED_STORAGE_CONFIG:
+   default:
+    - S3Storage
+    - s3_bucket: <bucket_name>
+      storage_path: /registry 
+      s3_access_key: <s3_access_key>
+      s3_secret_key: <s3_secret_key>
+      host: <host_name>
+----
+
+. Export the `AWS_ACCESS_KEY_ID` by using the `access_key` credential obtained in Step 7:
++
+[source,terminal]
+----
+$ export AWS_ACCESS_KEY_ID=<access_key> 
+----
+
+. Export the `AWS_SECRET_ACCESS_KEY` by using the `secret_key` obtained in Step 7:
++
+[source,terminal]
+----
+$ export AWS_SECRET_ACCESS_KEY=<secret_key>
+----
+
+. Sync the `quay` bucket to the `/tmp/quay-backup/blob-backup/` directory from the `hostname` of your `DISTRIBUTED_STORAGE_CONFIG`:
++
+[source,terminal]
+----
+$ aws s3 sync s3://<bucket_name>  /tmp/quay-backup/blob-backup/ --source-region us-east-2
+----
++
+Example output:
++
+----
+download: s3://<user_name>/registry/sha256/9c/9c3181779a868e09698b567a3c42f3744584ddb1398efe2c4ba569a99b823f7a to registry/sha256/9c/9c3181779a868e09698b567a3c42f3744584ddb1398efe2c4ba569a99b823f7a
+download: s3://<user_name>/registry/sha256/e9/e9c5463f15f0fd62df3898b36ace8d15386a6813ffb470f332698ecb34af5b0d to registry/sha256/e9/e9c5463f15f0fd62df3898b36ace8d15386a6813ffb470f332698ecb34af5b0d
+----
+[NOTE]
+====
+It is recommended that you delete the `quay-config.yaml` file after syncing the `quay` bucket because it contains sensitive information. The `quay-config.yaml` file will not be lost because it is backed up in the `quay-backup.tar.gz` file. 
+====

--- a/modules/restoring-red-hat-quay-standalone.adoc
+++ b/modules/restoring-red-hat-quay-standalone.adoc
@@ -1,0 +1,238 @@
+:_content-type: PROCEDURE
+[[restoring-red-hat-quay-standalone]]
+= Restoring {productname} on standalone deployments 
+
+This procedure describes how to restore {productname} on standalone deployments. 
+
+.Prerequisites 
+
+* You have backed up your {productname} deployment. 
+
+.Procedure 
+
+. Create a new directory that will bind-mount to `/conf/stack` inside of the {productname} container:
++
+[source,terminal]
+----
+$ mkdir /opt/new-quay-install
+----
+
+. Copy the contents of your temporary backup directory created in xref:backing-up-red-hat-quay-standalone[Backing up {productname} on standalone deployments] to the `new-quay-install1` directory created in Step 1:
++
+[source,terminal]
+----
+$ cp /tmp/quay-backup/quay-backup.tar.gz /opt/new-quay-install/
+----
+
+. Change into the `new-quay-install` directory by entering the following command:
++
+[source,terminal]
+----
+$ cd /opt/new-quay-install/
+----
+
+. Extract the contents of your {productname} directory: 
++
+[source,terminal]
+----
+$ tar xvf /tmp/quay-backup/quay-backup.tar.gz *
+----
++
+Example output:
++
+----
+config.yaml
+config.yaml.bak
+extra_ca_certs/
+extra_ca_certs/ca.crt
+ssl.cert
+ssl.key
+----
+
+. Recall the `DB_URI` from your backed-up `config.yaml` file by entering the following command: 
++
+[source,terminal]
+----
+$ grep DB_URI config.yaml
+----
++
+Example output:
++
+[source,yaml]
+----
+postgresql://<username>:test123@172.24.10.50/quay
+----
+
+. Run the following command to enter the PostgreSQL database server: 
++
+[source,terminal]
+----
+$ sudo postgres 
+----
+
+. Enter psql and create a new database in 172.24.10.50 to restore the quay databases, for example, `example_restore_registry_quay_database`, by entering the following command:
++
+[source,terminal]
+----
+$ psql "host=172.24.10.50  port=5432 dbname=postgres user=<username>  password=test123"
+postgres=> CREATE DATABASE example_restore_registry_quay_database;
+----
++
+Example output:
++
+----
+CREATE DATABASE
+----
+
+. Connect to the database by running the following command:
++
+[source,terminal]
+----
+postgres=# \c "example-restore-registry-quay-database";
+----
++
+Example output:
++
+[source,terminal]
+----
+You are now connected to database "example-restore-registry-quay-database" as user "postgres".
+----
+
+. Create a `pg_trmg` extension of your Quay database by running the following command:
++
+[source,terminal]
+----
+example_restore_registry_quay_database=> CREATE EXTENSION IF NOT EXISTS pg_trgm;
+----
++
+Example output:
++
+[source,terminal]
+----
+CREATE EXTENSION
+----
+
+. Exit the postgres CLI by entering the following command: 
++
+[source,terminal]
+----
+\q
+----
+
+. Import the database backup to your new database by running the following command:
++
+[source,terminal]
+----
+$ psql "host=172.24.10.50 port=5432 dbname=example_restore_registry_quay_database user=<username> password=test123"  -W <  /tmp/quay-backup/quay-backup.sql
+----
++
+Example output:
++
+----
+SET
+SET
+SET
+SET
+SET
+----
++
+Update the value of `DB_URI` in your `config.yaml` from `postgresql://<username>:test123@172.24.10.50/quay` to `postgresql://<username>:test123@172.24.10.50/example-restore-registry-quay-database` before restarting the {productname} deployment.
++
+[NOTE]
+====
+The DB_URI format is `DB_URI postgresql://<login_user_name>:<login_user_password>@<postgresql_host>/<quay_database>`. If you are moving from one PostgreSQL server to another PostgreSQL server, update the value of `<login_user_name>`, `<login_user_password>` and `<postgresql_host>` at the same time.
+====
+
+
+
+. In the `/opt/new-quay-install` directory, print the contents of your `DISTRIBUTED_STORAGE_CONFIG` bundle:
++
+[source,terminal]
+----
+$ cat config.yaml | grep DISTRIBUTED_STORAGE_CONFIG -A10
+----
++
+Example output:
++
+[source,yaml]
+----
+DISTRIBUTED_STORAGE_CONFIG:
+   default:
+DISTRIBUTED_STORAGE_CONFIG:
+   default:
+    - S3Storage
+    - s3_bucket: <bucket_name>
+      storage_path: /registry 
+      s3_access_key: <s3_access_key>
+      s3_secret_key: <s3_secret_key>
+      host: <host_name>
+----
++
+[NOTE]
+====
+Your `DISTRIBUTED_STORAGE_CONFIG` in `/opt/new-quay-install` must be updated before restarting your {productname} deployment. 
+====
+
+. Export the `AWS_ACCESS_KEY_ID` by using the `access_key` credential obtained in Step 13:
++
+[source,terminal]
+----
+$ export AWS_ACCESS_KEY_ID=<access_key> 
+----
+
+. Export the `AWS_SECRET_ACCESS_KEY` by using the `secret_key` obtained in Step 13:
++
+[source,terminal]
+----
+$ export AWS_SECRET_ACCESS_KEY=<secret_key>
+----
+
+. Create a new s3 bucket by entering the following command:
++
+[source,terminal]
+----
+$ aws s3 mb s3://<new_bucket_name>  --region us-east-2
+----
++
+Example output:
++
+[source,terminal]
+----
+$ make_bucket: quay
+----
+
+. Upload all blobs to the new s3 bucket by entering the following command: 
++
+[source,terminal]
+----
+$ aws s3 sync --no-verify-ssl \
+--endpoint-url <example_endpoint_url> <1>
+/tmp/quay-backup/blob-backup/. s3://quay/
+----
+<1> The {productname} registry endpoint must be the same before backup and after restore. 
++
+Example output: 
++
+[source,terminal]
+----
+upload: ../../tmp/quay-backup/blob-backup/datastorage/registry/sha256/50/505edb46ea5d32b5cbe275eb766d960842a52ee77ac225e4dc8abb12f409a30d to s3://quay/datastorage/registry/sha256/50/505edb46ea5d32b5cbe275eb766d960842a52ee77ac225e4dc8abb12f409a30d
+upload: ../../tmp/quay-backup/blob-backup/datastorage/registry/sha256/27/27930dc06c2ee27ac6f543ba0e93640dd21eea458eac47355e8e5989dea087d0 to s3://quay/datastorage/registry/sha256/27/27930dc06c2ee27ac6f543ba0e93640dd21eea458eac47355e8e5989dea087d0
+upload: ../../tmp/quay-backup/blob-backup/datastorage/registry/sha256/8c/8c7daf5e20eee45ffe4b36761c4bb6729fb3ee60d4f588f712989939323110ec to s3://quay/datastorage/registry/sha256/8c/8c7daf5e20eee45ffe4b36761c4bb6729fb3ee60d4f588f712989939323110ec
+...
+----
+
+. Before restarting your {productname} deployment, update the storage settings in your config.yaml:
++
+[source,yaml]
+----
+DISTRIBUTED_STORAGE_CONFIG:
+   default:
+DISTRIBUTED_STORAGE_CONFIG:
+   default:
+    - S3Storage
+    - s3_bucket: <new_bucket_name>       
+      storage_path: /registry 
+      s3_access_key: <s3_access_key>
+      s3_secret_key: <s3_secret_key>
+      host: <host_name>
+----

--- a/modules/restoring-red-hat-quay.adoc
+++ b/modules/restoring-red-hat-quay.adoc
@@ -1,13 +1,13 @@
 [[restoring-up-red-hat-quay]]
 = Restoring {productname}
 
-This procedure is used to restore {productname} when the {productname} Operator manages the database. It should be performed after a backup of your {productname} registry has been performed. See xref:backing-up-red-hat-quay.adoc#backing-up-red-hat-quay[Backing up {productname}] for more information.
+This procedure is used to restore {productname} when the {productname} Operator manages the database. It should be performed after a backup of your {productname} registry has been performed. See xref:backing-up-red-hat-quay-operator.adoc#backing-up-red-hat-quay-operator[Backing up {productname}] for more information.
 
 
 .Prerequisites
 
 * {productname} is deployed on OpenShift Container Platform using the {productname} Operator.
-* A backup of the {productname} configuration managed by the {productname} Operator has been created following the instructions in the xref:backing-up-red-hat-quay.adoc#backing-up-red-hat-quay[Backing up {productname}] section
+* A backup of the {productname} configuration managed by the {productname} Operator has been created following the instructions in the xref:backing-up-red-hat-quay-operator.adoc#backing-up-red-hat-quay-operator[Backing up {productname}] section
 * Your {productname} database has been backed up.
 * The object storage bucket used by {productname} has been backed up.
 * The components `quay`, `postgres` and `objectstorage` are set to `managed: true`
@@ -23,7 +23,7 @@ If your deployment contains partially unmanaged database or storage components a
 
 [NOTE]
 ====
-These instructions assume you have followed the process in the xref:backing-up-red-hat-quay.adoc#backing-up-red-hat-quay[Backing up {productname}] guide and create the backup files with the same names.
+These instructions assume you have followed the process in the xref:backing-up-red-hat-quay-operator.adoc#backing-up-red-hat-quay-operator[Backing up {productname}] guide and create the backup files with the same names.
 ====
 
 . Restore the backed up {productname} configuration and the generated keys from the backup:

--- a/modules/standalone-deployment-backup-restore.adoc
+++ b/modules/standalone-deployment-backup-restore.adoc
@@ -1,0 +1,5 @@
+:_content-type: CONCEPT
+[id="standalone-deployment-backup-restore"]
+= Backing up and restoring {productname} on a standalone deployment 
+
+Use the content within this section to back up and restore {productname} in standalone deployments. 


### PR DESCRIPTION
https://stevsmit.github.io/quay-docs/backup-restore/index.html

Please note that I have *not* tested this. I do not have a standalone deployment of Red Hat Quay. **This is just a draft. I am aware some content might require revision**.

The last backup/restore procedure there were many changes between QE and PM (Daniel). By submitting this prior to attempting it myself, I'm hoping to avoid multiple iterations of re-writes.

Preview: https://stevsmit.github.io/quay-docs/backup-restore/index.html#standalone-deployment-backup-restore

Issue: https://issues.redhat.com/browse/PROJQUAY-3108

Based on the following instructions given to me by Ivan: https://docs.google.com/document/d/1QizE6IShRWf36ToxuE-V1yxf3u9xrz4b_xttAipHa9A/edit