### PR TITLE
Adds mirror config fields to config docs

### DIFF
--- a/api/master.adoc
+++ b/api/master.adoc
@@ -233,3 +233,10 @@ include::modules/api-user-deleteStar.adoc[leveloffset=+3]
 include::modules/api-user-getUserInformation.adoc[leveloffset=+3]
 
 include::modules/api-definitions.adoc[leveloffset=+2]
+
+// do not remove 
+[id="api-config-examples"]
+== API configuration examples
+
+include::modules/external-registry-config-api-example.adoc[leveloffset=+2]
+include::modules/root-rule-config-api-example.adoc[leveloffset=+2]

--- a/modules/api-definitions.adoc
+++ b/modules/api-definitions.adoc
@@ -69,9 +69,9 @@ _optional_|Number of seconds after next_start_date to begin synchronizing.|integ
 |**robot_username** + 
 _optional_|Username of robot which will be used for image pushes.|string
 |**root_rule** + 
-_optional_|A list of glob-patterns used to determine which tags should be synchronized.|object
+_optional_|A list of glob-patterns used to determine which tags should be synchronized. See xref:root-rule-config-api-example[root_rule api example] for object reference. |object
 |**external_registry_config** + 
-_optional_||object
+_optional_|xref:external-registry-config-api-example[external_registry_config example] |object
 |===
 
 [[_apierrordescription]]

--- a/modules/api-mirror-changeRepoMirrorConfig.adoc
+++ b/modules/api-mirror-changeRepoMirrorConfig.adoc
@@ -44,9 +44,9 @@ _optional_|Number of seconds after next_start_date to begin synchronizing.|integ
 |**robot_username** + 
 _optional_|Username of robot which will be used for image pushes.|string
 |**root_rule** + 
-_optional_|A list of glob-patterns used to determine which tags should be synchronized.|object
+_optional_|A list of glob-patterns used to determine which tags should be synchronized. See xref:root-rule-config-api-example[root_rule api example] for object reference.|object
 |**external_registry_config** + 
-_optional_||object
+_optional_|xref:external-registry-config-api-example[external_registry_config example] |object
 |===
 
 

--- a/modules/api-mirror-createRepoMirrorConfig.adoc
+++ b/modules/api-mirror-createRepoMirrorConfig.adoc
@@ -32,21 +32,21 @@ Create the repository mirroring configuration.
 |**is_enabled** + 
 _optional_|Used to enable or disable synchronizations.|boolean
 |**external_reference** + 
-_optional_|Location of the external repository.|string
+_required_|Location of the external repository.|string
 |**external_registry_username** + 
 _optional_|Username used to authenticate with external registry.|
 |**external_registry_password** + 
 _optional_|Password used to authenticate with external registry.|
 |**sync_start_date** + 
-_optional_|Determines the next time this repository is ready for synchronization.|string
+_required_|Determines the next time this repository is ready for synchronization.|string
 |**sync_interval** + 
-_optional_|Number of seconds after next_start_date to begin synchronizing.|integer
+_required_|Number of seconds after next_start_date to begin synchronizing.|integer
 |**robot_username** + 
-_optional_|Username of robot which will be used for image pushes.|string
+_required_|Username of robot which will be used for image pushes.|string
 |**root_rule** + 
-_optional_|A list of glob-patterns used to determine which tags should be synchronized.|object
+_required_|A list of glob-patterns used to determine which tags should be synchronized. See xref:root-rule-config-api-example[root_rule api example] for object reference.|object
 |**external_registry_config** + 
-_optional_||object
+_optional_|xref:external-registry-config-api-example[external_registry_config example] |object
 |===
 
 

--- a/modules/config-fields-mirroring.adoc
+++ b/modules/config-fields-mirroring.adoc
@@ -21,7 +21,8 @@
  + 
  **Default:** `false`
 
- |**REPO_MIRROR_ROLLBACK** | Boolean | When set to `true`, the repository rolls back after a failed mirror attempt. 
+|**REPO_MIRROR_ROLLBACK** | Boolean | When set to `true`, the repository rolls back after a failed mirror attempt. 
 
 *Default*: `false`
+
 |===

--- a/modules/external-registry-config-api-example.adoc
+++ b/modules/external-registry-config-api-example.adoc
@@ -1,0 +1,25 @@
+:_content-type: CONCEPT
+[id="external-registry-config-api-example"]
+
+=== external_registry_config object reference 
+
+[source,yaml]
+----
+{
+        "is_enabled": True,
+        "external_reference": "quay.io/redhat/quay",
+        "sync_interval": 5000,
+        "sync_start_date": datetime(2020, 0o1, 0o2, 6, 30, 0),
+        "external_registry_username": "fakeUsername",
+        "external_registry_password": "fakePassword",
+        "external_registry_config": {
+            "verify_tls": True,
+            "unsigned_images": False,
+            "proxy": {
+                "http_proxy": "http://insecure.proxy.corp",
+                "https_proxy": "https://secure.proxy.corp",
+                "no_proxy": "mylocalhost",
+            },
+        },
+    }
+----

--- a/modules/root-rule-config-api-example.adoc
+++ b/modules/root-rule-config-api-example.adoc
@@ -1,0 +1,11 @@
+:_content-type: CONCEPT
+[id="root-rule-config-api-example"]
+
+=== rule_rule object reference 
+
+[source,yaml]
+----
+    {
+            "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest", "foo", "bar"]},
+        }
+----


### PR DESCRIPTION
Issues:

https://issues.redhat.com/browse/PROJQUAY-3758
https://issues.redhat.com/browse/PROJQUAY-4742

Preview: https://stevsmit.github.io/quay-docs/api-example/index.html#external-registry-config-api-example 
