### PR TITLE
Removed duplicate configuration parameter

### DIFF
--- a/modules/config-fields-scanner.adoc
+++ b/modules/config-fields-scanner.adoc
@@ -22,9 +22,6 @@
 **Example:** + 
 `http://192.168.99.101:6060`
 | **SECURITY_SCANNER_V4_PSK** | String | The generated pre-shared key (PSK) for Clair
-| **SECURITY_SCANNER_INDEXING_INTERVAL** | Number | The number of seconds between indexing intervals in the security scanner + 
- + 
-**Default:** 30
 // TODO 36 Check that SECURITY_SCANNER_NOTIFICATIONS can be dropped 
 // | **SECURITY_SCANNER_NOTIFICATIONS** | String | 
 | **SECURITY_SCANNER_ENDPOINT** | String |  The endpoint for the V2 security scanner + 
@@ -34,7 +31,9 @@
  + 
 **Example:** + 
 `http://192.168.99.100:6060`
-| **SECURITY_SCANNER_INDEXING_INTERVAL** | String | This parameter is used to determine the number of seconds between indexing intervals in the security scanner. When indexing is triggered, {productname} will query its database for manifests that must be indexed by Clair. These include manifests that have not yet been indexed and manifests that previously failed indexing. 
+| **SECURITY_SCANNER_INDEXING_INTERVAL** | Number | This parameter is used to determine the number of seconds between indexing intervals in the security scanner. When indexing is triggered, {productname} will query its database for manifests that must be indexed by Clair. These include manifests that have not yet been indexed and manifests that previously failed indexing.
+
+**Default:** 30
 |===
 
 


### PR DESCRIPTION
I'm submitting this PR because I found that **SECURITY_SCANNER_INDEXING_INTERVAL** configuration parameter is duplicated inside the documentation

Link to [docs](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/configure_red_hat_quay/index#config-fields-scanner) 