### PR TITLE
changes to modules/clair-openshift-airgap-database.adoc, fixed indentation

### DIFF
--- a/modules/clair-openshift-airgap-database-standalone.adoc
+++ b/modules/clair-openshift-airgap-database-standalone.adoc
@@ -51,12 +51,12 @@ indexer:
     layer_scan_concurrency: 5
     migrations: true
     scanner:
-    repo:
-      rhel-repository-scanner: <2>
-        repo2cpe_mapping_file: /data/cpe-map.json
-    package:
-      rhel_containerscanner: <3>
-        name2repos_mapping_file: /data/repo-map.json
+      repo:
+        rhel-repository-scanner: <2>
+          repo2cpe_mapping_file: /data/cpe-map.json
+      package:
+        rhel_containerscanner: <3>
+          name2repos_mapping_file: /data/repo-map.json
 ----
 <1> Replace the value of the `host` in the multiple `connstring` fields with `localhost`.
 <2> For more information about the `rhel-repository-scanner` parameter, see "Mapping repositories to Common Product Enumeration information".

--- a/modules/clair-openshift-airgap-database.adoc
+++ b/modules/clair-openshift-airgap-database.adoc
@@ -51,12 +51,12 @@ indexer:
     layer_scan_concurrency: 5
     migrations: true
     scanner:
-    repo:
-      rhel-repository-scanner: <2>
-        repo2cpe_mapping_file: /data/cpe-map.json
-    package:
-      rhel_containerscanner: <3>
-        name2repos_mapping_file: /data/repo-map.json
+      repo:
+        rhel-repository-scanner: <2>
+          repo2cpe_mapping_file: /data/cpe-map.json
+      package:
+        rhel_containerscanner: <3>
+          name2repos_mapping_file: /data/repo-map.json
 ----
 <1> Replace the value of the `host` in the multiple `connstring` fields with `localhost`.
 <2> For more information about the `rhel-repository-scanner` parameter, see "Mapping repositories to Common Product Enumeration information".


### PR DESCRIPTION

 cpe-map.json and repo-map.json files are not properly read due to the incorrect indentation. This in return caused a failure in Clair to scan images and it took a while to figure out why. 
