### PR TITLE
Updated the docs so geo replication operator docs are in the correct place

### DIFF
--- a/upgrade_quay/master.adoc
+++ b/upgrade_quay/master.adoc
@@ -14,12 +14,12 @@ The {productname} Operator should be upgraded using the link:https://docs.opensh
 The procedure for upgrading a proof-of-concept or highly available installation of {productname} and Clair is documented in the section "Standalone upgrade".
 
 include::modules/operator-upgrade.adoc[leveloffset=+1]
+include::modules/upgrading-geo-repl-quay-operator.adoc[leveloffset=+2]
 
 include::modules/proc_upgrade_standalone.adoc[leveloffset=+1]
 include::modules/upgrading-geo-repl-quay.adoc[leveloffset=+2]
 
 include::modules/qbo-operator-upgrade.adoc[leveloffset=+1]
-include::modules/upgrading-geo-repl-quay-operator.adoc[leveloffset=+2]
 
 
 include::modules/downgrade-quay-deployment.adoc[leveloffset=+1]


### PR DESCRIPTION
Currently, the docs for geo replication operator upgrades are under the chapter about upgrading the quay bridge operator. This is the incorrect place to host these and can cause customers to miss this documentation, especially when they're not using the bridge operator.