### PR TITLE
Specifying s3_region on `S3Storage` CloudStorage

### DIFF
--- a/modules/backing-up-red-hat-quay-standalone.adoc
+++ b/modules/backing-up-red-hat-quay-standalone.adoc
@@ -102,6 +102,7 @@ DISTRIBUTED_STORAGE_CONFIG:
       s3_access_key: <s3_access_key>
       s3_secret_key: <s3_secret_key>
       host: <host_name>
+      s3_region: <s3_region_name>
 ----
 
 . Export the `AWS_ACCESS_KEY_ID` by using the `access_key` credential obtained in Step 7:

--- a/modules/config-fields-storage-aws.adoc
+++ b/modules/config-fields-storage-aws.adoc
@@ -10,6 +10,7 @@ DISTRIBUTED_STORAGE_CONFIG:
   default:
     - S3Storage <1>
     - host: s3.us-east-2.amazonaws.com
+      s3_region: us-east-2
       s3_access_key: ABCDEFGHIJKLMN
       s3_secret_key: OL3ABCDEFGHIJKLMN
       s3_bucket: quay_bucket

--- a/modules/connecting-s3-timeout.adoc
+++ b/modules/connecting-s3-timeout.adoc
@@ -19,6 +19,7 @@ DISTRIBUTED_STORAGE_CONFIG:
     default:
         - S3Storage
         - host: s3.ap-south-1.amazonaws.com
+          s3_region: ap-south-1
           s3_access_key: *****************
           s3_bucket: quay-bucket-1
           s3_secret_key: *********************************

--- a/modules/operator-unmanaged-storage.adoc
+++ b/modules/operator-unmanaged-storage.adoc
@@ -15,6 +15,7 @@ DISTRIBUTED_STORAGE_CONFIG:
   s3Storage:
     - S3Storage
     - host: s3.us-east-2.amazonaws.com
+      s3_region: us-east-2
       s3_access_key: ABCDEFGHIJKLMN
       s3_secret_key: OL3ABCDEFGHIJKLMN
       s3_bucket: quay_bucket

--- a/modules/restoring-red-hat-quay-standalone.adoc
+++ b/modules/restoring-red-hat-quay-standalone.adoc
@@ -166,6 +166,7 @@ DISTRIBUTED_STORAGE_CONFIG:
       s3_access_key: <s3_access_key>
       s3_secret_key: <s3_secret_key>
       host: <host_name>
+      s3_region: <s3_region_name>
 ----
 +
 [NOTE]
@@ -235,4 +236,5 @@ DISTRIBUTED_STORAGE_CONFIG:
       s3_access_key: <s3_access_key>
       s3_secret_key: <s3_secret_key>
       host: <host_name>
+      s3_region: <s3_region_name>
 ----


### PR DESCRIPTION
Due to the boto3 issues (https://github.com/boto/boto3/issues/2989) setting the X-Amz-Credential header, it is recommended to set either the `s3_region` or the `endpoint_url` field when configuring an S3Storage provider.

This commit adds the `s3_region` field to all documented S3Storage examples in the documentation.