### PR TITLE
Fix for 'Postgres Operator' product name

### DIFF
--- a/modules/con_quay_ha_prereq.adoc
+++ b/modules/con_quay_ha_prereq.adoc
@@ -11,7 +11,7 @@ Here are a few things you need to know before you begin the {productname} high a
 
 * Either Postgres or MySQL can be used to provide the database service. Postgres was chosen here as the database because it includes the features needed to support Clair security scanning. Other options include:
 ** Crunchy Data PostgreSQL Operator: Although not supported directly by Red Hat,
-the link:https://access.crunchydata.com/documentation/postgres-operator/latest/[CrunchDB Operator]
+the link:https://access.crunchydata.com/documentation/postgres-operator/latest/[Postgres Operator]
 is available from link:https://www.crunchydata.com/[Crunchy Data] for use with {productname}.
 If you take this route, you should have a support contract with Crunchy Data and
 work directly with them for usage guidance or issues relating to the operator and their database.


### PR DESCRIPTION
The name of the Crunchy Data operator is "Postgres Operator" and not "CrunchDB Operator". "CrunchyDB" does not exist, so this simple patch fixes the documentation to accurately reflect that.

@stevsmit 