### PR TITLE
set expiration through API: fix example

### DIFF
--- a/modules/setting-tag-expiration-api.adoc
+++ b/modules/setting-tag-expiration-api.adoc
@@ -19,7 +19,7 @@ $ curl -X PUT \
   -H "Authorization: Bearer <bearer_token>" \
   -H "Content-Type: application/json" \
   --data '{
-    "manifest_digest": "<manifest_digest>"
+    "expiration": "<seconds since epoch>"
   }' \
   https://<quay-server.example.com>/api/v1/repository/<namespace>/<repository_name>/tag/<tag>
 ----


### PR DESCRIPTION
The example looks like a copy/paste from another place and was not updated. Fix the payload to match was expected.