### PR TITLE
Quay 3.12: Fix Typo In LDAP Configuration Docs

### DIFF
--- a/modules/config-fields-ldap.adoc
+++ b/modules/config-fields-ldap.adoc
@@ -40,7 +40,7 @@ With this field, administrators can add or remove superusers without having to u
 
 This field requires that your `AUTHENTICATION_TYPE` is set to `LDAP`. 
 
-| **GLOBAL_READONLY_SUPER_USERS** | String | When set, grants users of this list read access to all repositories, regardless of whether they are public repositories. Only works for those superusers defined with the `LDAP_SUPERUSER_FILTER` configuration field.
+| **LDAP_GLOBAL_READONLY_SUPERUSER_FILTER** | String | When set, grants users of this list read access to all repositories, regardless of whether they are public repositories. Only works for those superusers defined with the `LDAP_SUPERUSER_FILTER` configuration field.
 
 | **LDAP_RESTRICTED_USER_FILTER** | String | Subset of the `LDAP_USER_FILTER` configuration field. When configured, allows {productname} administrators the ability to configure Lightweight Directory Access Protocol (LDAP) users as restricted users when {productname} uses LDAP as its authentication provider.
 


### PR DESCRIPTION
Starting with Quay 3.12 there was a new configuration option added called LDAP_GLOBAL_READONLY_SUPERUSER_FILTER. When the documentation for this feature was originally written(0b0eabbc338c472f0dba3be30baeb06e46cf5b6e) it was incorrectly called GLOBAL_READONLY_SUPER_USERS.

Initial feature added to Quay here https://github.com/quay/quay/pull/2917. Reference to code in latest commit on redhat-3.12 branch https://github.com/quay/quay/blob/2c4c7570513b6dd205f7ce53ec25716baac45d85/data/users/__init__.py#L72-L74.

ref: https://issues.redhat.com/browse/PROJQUAY-7044

This is a cherry-pick of commit 6dceb39045289e232ab8fa702b551a907b7771ed