### PR TITLE
Quay 3.14: Fix typo in upgrade documentation

### DIFF
--- a/modules/operator-upgrade.adoc
+++ b/modules/operator-upgrade.adoc
@@ -18,7 +18,7 @@ When the {productname} Operator is installed by Operator Lifecycle Manager, it m
 
 The standard approach for upgrading installed Operators on {ocp} is documented at link:https://docs.openshift.com/container-platform/{ocp-y}/operators/admin/olm-upgrading-operators.html[Upgrading installed Operators].
 
-In general, {productname} supports upgrades from a prior (N-1) minor version only.  For example, upgrading directly from {productname} 3.5 to the latest version of {productmin} is not supported. Instead, users would have to upgrade as follows:
+In general, {productname} supports upgrades from a prior (N-1) minor version only.  For example, upgrading directly from {productname} 3.5 to the latest version of {producty} is not supported. Instead, users would have to upgrade as follows:
 
 . 3.9.z -> 3.10.z
 . 3.10.z -> 3.11.z

--- a/modules/operator-upgrade.adoc
+++ b/modules/operator-upgrade.adoc
@@ -18,7 +18,7 @@ When the {productname} Operator is installed by Operator Lifecycle Manager, it m
 
 The standard approach for upgrading installed Operators on {ocp} is documented at link:https://docs.openshift.com/container-platform/{ocp-y}/operators/admin/olm-upgrading-operators.html[Upgrading installed Operators].
 
-In general, {productname} supports upgrades from a prior (N-1) minor version only.  For example, upgrading directly from {productname} 3.5 to the latest version of {producty-min} is not supported. Instead, users would have to upgrade as follows:
+In general, {productname} supports upgrades from a prior (N-1) minor version only.  For example, upgrading directly from {productname} 3.5 to the latest version of {productmin} is not supported. Instead, users would have to upgrade as follows:
 
 . 3.9.z -> 3.10.z
 . 3.10.z -> 3.11.z


### PR DESCRIPTION
I'm opening this PR because I found a small typo in the upgrade documentation.
producty-min should be replaced with producty

Ref: https://issues.redhat.com/browse/PROJQUAY-8977
