### PR TITLE
fixing small typo

### DIFF
--- a/modules/understanding-configuration-file.adoc
+++ b/modules/understanding-configuration-file.adoc
@@ -8,7 +8,7 @@
 [id="understanding-configuration-file"]
 = Understanding the {productname} configuration file
 
-Whether deployed on premise of by the {productname-ocp} Operator, the registry's behavior is defined by the `config.yaml` file. The `config.yaml` file must include all required configuration fields for the registry to start. {productname} administrators can also define optional parameters that customize their registry, such as authentication parameters, storage parameters, proxy cache parameters, and so on.
+Whether deployed on premise or by the {productname-ocp} Operator, the registry's behavior is defined by the `config.yaml` file. The `config.yaml` file must include all required configuration fields for the registry to start. {productname} administrators can also define optional parameters that customize their registry, such as authentication parameters, storage parameters, proxy cache parameters, and so on.
 
 The `config.yaml` file must be written using valid YAML ("YAML Ain't Markup Language") syntax, and {productname} cannot start if the file itself contains any formatting errors or missing required fields. Regardless of deployment type, whether that is on premise or {productname-ocp} that is configured by the Operator, the YAML principles stay the same, even if the required configuration fields are slightly different.
 


### PR DESCRIPTION
### What does this pull request change?
This pull request fixes a small typo in Quay documentation.

Version(s): 3.x

### Quay Documentation link: [Quay Official Documentation](https://docs.redhat.com/en/documentation/red_hat_quay/3/html/configure_red_hat_quay/understanding-configuration-file#:~:text=Whether%20deployed%20on%20premise%20of%20by%20the%20Red%20Hat%20Quay%20on%20OpenShift%20Container%20Platform%20Operator%2C%20the%20registry%E2%80%99s%20behavior%20is%20defined%20by%20the%20config.yaml%20file.%20The%20config.yaml%20file%20must%20include%20all%20required%20configuration%20fields%20for%20the%20registry%20to%20start.)


### What issues does this pull request fix or reference?
https://issues.redhat.com/browse/PROJQUAY-9247

