### PR TITLE
Update Clair PostgreSQL database documentation

### DIFF
--- a/modules/clair-postgresql-database-update.adoc
+++ b/modules/clair-postgresql-database-update.adoc
@@ -39,7 +39,7 @@ $ sudo podman run -d --name <clair_migration_postgresql_database> <1>
 ----
 +
 <1> Insert a name for your Clair PostgreSQL 15 migration database.
-<2> Your new Clair PostgreSQL 15 database container IP address. Can obtained by running the following command: `sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" postgresql-quay`. 
+<2> Your new Clair PostgreSQL 15 database container IP address can be obtained by running the command: `sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" postgresql-quay`. 
 <3> You must specify a different volume mount point than the one from your initial Clair PostgreSQL 13 deployment, and modify the access control lists for said directory. For example:
 +
 [source,terminal]


### PR DESCRIPTION
Correcting the sentence in [Quay documentation](https://docs.redhat.com/en/documentation/red_hat_quay/3/html/vulnerability_reporting_with_clair_on_red_hat_quay/clair-standalone-configure#clair-standalone-upgrade:~:text=Your%20new%20Clair%20PostgreSQL%2015%20database%20container%20IP%20address.%20Can%20obtained%20by%20running%20the%20following%20command%3A).

JIRA link: https://issues.redhat.com/browse/PROJQUAY-9252
