### PR TITLE
Clarify extra CA trust bundles on Quay Operator (OCPBUGS-85543).

### DIFF
--- a/modules/adding-ca-certs-to-config.adoc
+++ b/modules/adding-ca-certs-to-config.adoc
@@ -3,7 +3,9 @@
 [id="adding-ca-certs-to-config"]
 = Adding additional Certificate Authorities to {productname-ocp}
 
-The following example shows you how to add additional Certificate Authorities to your {productname-ocp} deployment.
+The following example shows you how to add additional Certificate Authorities to your {productname-ocp} deployment by extending the `configBundleSecret`.
+
+Additional CAs are not declared as an `extra_ca_certs` field inside `config.yaml`. Each CA is a separate entry in the Secret: the key must start with `extra_ca_cert_`, and the remainder of the key name becomes the file name under `conf/stack/extra_ca_certs/` after the Operator reconciles the registry.
 
 .Prerequisites
 
@@ -33,7 +35,7 @@ $ oc -n <namespace> create secret generic extra-ca-certificate-config-bundle-sec
   --dry-run=client -o yaml > extra-ca-certificate-config-bundle-secret.yaml
 ----
 <1> Where `<config.yaml>` is your `base64 decoded` `config.yaml` file.
-<2> The extra CA file to be added to into the system trust bundle.
+<2> The extra CA file to be added to the system trust bundle.
 <3> Optional. A second CA file to be added into the system trust bundle.
 <4> Optional. A third CA file to be added into the system trust bundle.
 
@@ -57,7 +59,7 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: custom-ssl-config-bundle-secret
+  name: extra-ca-certificate-config-bundle-secret
   namespace: <namespace>
 ----
 

--- a/modules/config-additional-ca-certs-operator.adoc
+++ b/modules/config-additional-ca-certs-operator.adoc
@@ -3,8 +3,19 @@
 [id="config-additional-cas-ocp"]
 = Adding additional Certificate Authorities to {productname-ocp}
 
-On {productname-ocp}, the `extra_ca_certs` configuration field is is used to populate additional Certificate Authorities (CAs) into the CA directory, which then adds the CAs into the system trust bundle. These certificates are used by {productname} to verify SSL/TLS connections with external services like LDAP, OIDC, and storage systems. 
+On {productname-ocp}, additional Certificate Authorities (CAs) are merged into the registry trust store from the `conf/stack/extra_ca_certs/` directory inside the final configuration bundle. {productname} uses those CAs to verify TLS to external services such as LDAP, OIDC, and storage endpoints.
 
-When deploying or redeploying {productname-ocp}, you can add one, or multiple, CAs into the CA directory to ensure that external services are properly secured and validated. On {productname-ocp} deployments, you must manually add the `extra_ca_certs` configuration field to your `config.yaml` file and re-upload the `config.yaml` to {ocp}.
+This path is the same logical location as the `extra_ca_certs` directory used on standalone deployments. On {productname-ocp}, you do not create that directory on a node yourself. Instead, add each CA PEM file to the `configBundleSecret` as its own Secret data entry whose key name begins with `extra_ca_cert_`. The {productname} Operator extracts these keys when it reconciles the registry and writes the files under `conf/stack/extra_ca_certs/`. The file name in that directory is the key name with the `extra_ca_cert_` prefix removed. For example, a Secret key `extra_ca_cert_ldap-ca.pem` is available at runtime as `conf/stack/extra_ca_certs/ldap-ca.pem`.
 
-The following procedures show you how to download your existing configuration file, add additional CAs to your {productname-ocp} deployment, and then re-upload the configuration file.
+You do not add an `extra_ca_certs` list or block to `config.yaml` only to load those CAs on {productname-ocp}. The supported approach is the `extra_ca_cert_*` keys in the bundle Secret, as shown in the procedures that follow.
+
+When another setting requires an explicit path to one of those PEM files (for example, `ssl_ca_path` for a given integration), set the path in `config.yaml` to the runtime location under `conf/stack/extra_ca_certs/`, for example:
+
+[source,yaml]
+----
+# ...
+ssl_ca_path: conf/stack/extra_ca_certs/ldap-ca.pem
+# ...
+----
+
+The following procedures show you how to download your existing configuration file, include additional CA files in the `configBundleSecret`, and re-apply the bundle so that {ocp} deploys the updated configuration.

--- a/modules/creating-custom-ssl-certs-config-bundle.adoc
+++ b/modules/creating-custom-ssl-certs-config-bundle.adoc
@@ -34,7 +34,7 @@ $ oc -n <namespace> create secret generic custom-ssl-config-bundle-secret \
 ----
 <1> Where `<config.yaml>` is your `base64 decoded` `config.yaml` file.
 <2> Where `<ssl.cert>` is your `ssl.cert` file.
-<3> Optional. The `--from-file=extra_ca_cert_<name-of-certificate>.crt=ca-certificate-bundle.crt` field allows {productname} to recognize custom Certificate Authority (CA) files. If you are using LDAP, OIDC, or another service that uses custom CAs, you must add them via the `extra_ca_cert` path. For more information, see "Adding additional Certificate Authorities to {productname-ocp}."
+<3> Optional. Add each additional CA PEM using a Secret key that starts with `extra_ca_cert_` (for example, `--from-file=extra_ca_cert_<name-of-certificate>.crt=ca-certificate-bundle.crt`). The {productname} Operator writes these files under `conf/stack/extra_ca_certs/` in the deployed bundle. For LDAP, OIDC, or other integrations that need custom CAs, supply the PEMs this way and use `conf/stack/extra_ca_certs/<file>` in `config.yaml` when a field such as `ssl_ca_path` requires an explicit path.
 <4> Where `<ssl.key>` is your `ssl.key` file.
 
 . Optional. You can check the content of the `custom-ssl-config-bundle-secret.yaml` file by entering the following command:


### PR DESCRIPTION
Readers conflated an `extra_ca_certs` `config.yaml` field with supplying `extra_ca_cert_*` keys on the config bundle Secret. Document the Operator flow (Secret keys to `conf/stack/extra_ca_certs/`), when to set paths in `config.yaml`, and clean up related callouts and examples.