### PR TITLE
[PROJQUAY-11693] Document LOGIN_SCOPES requirements for OIDC discovery

### DIFF
--- a/modules/enabling-team-sync-oidc.adoc
+++ b/modules/enabling-team-sync-oidc.adoc
@@ -42,7 +42,7 @@ FEATURE_UI_V2: true
 <3>  Required. The address of the OIDC server that is being used for authentication. This URL should be such that a `GET` request to `<OIDC_SERVER>/.well-known/openid-configuration` returns the provider's configuration information. This configuration information is essential for the relying party (RP) to interact securely with the OpenID Connect provider and obtain necessary details for authentication and authorization processes.
 <4> Required. The name of the service that is being authenticated.
 <5> Required. The key name within the OIDC token payload that holds information about the user's group memberships. This field allows the authentication system to extract group membership information from the OIDC token so that it can be used with {productname}.
-<6> Required. Adds additional scopes that {productname} uses to communicate with the OIDC provider. Must include `'openid'`. Additional scopes are optional.
+<6> Required. Scopes {productname} requests during login. Must include `'openid'`. Each scope must also be listed in the IdP's `scopes_supported` from `/.well-known/openid-configuration`.
 <7> Whether to allow or disable the `/userinfo` endpoint. If using Azure Entra ID, set this field to `True`. Defaults to `False`.
 <8> Required. Whether to allow for team membership to be synced from a backing group in the authentication engine.
 <9> Optional. If enabled, non-superusers can setup team synchronization.

--- a/modules/oidc-config-fields.adoc
+++ b/modules/oidc-config-fields.adoc
@@ -26,7 +26,7 @@ You can configure {productname} to authenticate users through any OpenID Connect
  +
 **Example:** `e4a58ddd3d7408b7aec109e85564a0d153d3e846`
 | **{nbsp}{nbsp}{nbsp}.LOGIN_BINDING_FIELD** |String | Used when the internal authorization is set to LDAP. {productname} reads this parameter and tries to search through the LDAP tree for the user with this username. If it exists, it automatically creates a link to that LDAP account.
-| **{nbsp}{nbsp}{nbsp}.LOGIN_SCOPES** | Object | Adds additional scopes that {productname} uses to communicate with the OIDC provider. 
+| **{nbsp}{nbsp}{nbsp}.LOGIN_SCOPES** | Object | Scopes {productname} requests during the OIDC login flow. Must include `openid`. Each scope listed here must also appear in the IdP's `scopes_supported` array from `/.well-known/openid-configuration`.
 | **{nbsp}{nbsp}{nbsp}.OIDC_ENDPOINT_CUSTOM_PARAMS** | String | Support for custom query parameters on OIDC endpoints. The following endpoints are supported:
 `authorization_endpoint`, `token_endpoint`, and `user_endpoint`.
 | **{nbsp}{nbsp}{nbsp}.OIDC_ISSUER** | String | Allows the user to define the issuer to verify. For example, JWT tokens container a parameter known as `iss` which defines who issued the token. By default, this is read from the `.well-know/openid/configuration` endpoint, which is exposed by every OIDC provider. If this verification fails, there is no login. 


### PR DESCRIPTION
## Summary

- Update `.LOGIN_SCOPES` description in OIDC configuration fields to document that each configured scope must appear in the IdP's `scopes_supported` array from `/.well-known/openid-configuration`
- Update Team synchronization footnote 6 (`LOGIN_SCOPES`) with the same requirement

Fixes: https://redhat.atlassian.net/browse/PROJQUAY-11693

## Changes

### `modules/oidc-config-fields.adoc`
**Field:** `.LOGIN_SCOPES`

**Before:** Adds additional scopes that Red Hat Quay uses to communicate with the OIDC provider.

**After:** Scopes Red Hat Quay requests during the OIDC login flow. Must include `openid`. Each scope listed here must also appear in the IdP's `scopes_supported` array from `/.well-known/openid-configuration`.

### `modules/enabling-team-sync-oidc.adoc`
**Footnote 6 — `LOGIN_SCOPES`**

**Before:** Required. Adds additional scopes that Red Hat Quay uses to communicate with the OIDC provider. Must include `'openid'`. Additional scopes are optional.

**After:** Required. Scopes Red Hat Quay requests during login. Must include `'openid'`. Each scope must also be listed in the IdP's `scopes_supported` from `/.well-known/openid-configuration`.

## Test plan

- [ ] AsciiDoc builds without errors (if using local docs build)
- [ ] Published Configure Red Hat Quay → OIDC configuration fields reflects updated `.LOGIN_SCOPES` description
- [ ] Published Manage Red Hat Quay → Team synchronization reflects updated footnote 6
- [ ] Link PROJQUAY-11693 in Jira once PR is opened
