### PR TITLE
Revert "Cherry-pick #1632 to redhat-3.15: Adds the LDAP cache config field to the docs"

### DIFF
--- a/modules/config-fields-ldap.adoc
+++ b/modules/config-fields-ldap.adoc
@@ -69,14 +69,6 @@ This field requires that your `AUTHENTICATION_TYPE` is set to `LDAP`.
 | **LDAP_NETWORK_TIMEOUT** |Integer | Specifies the time limit, in seconds, for establishing a connection to the LDAP server. This is the maximum time {productname} waits for a response during network operations, similar to the `-o nettimeout` option in `ldapsearch`. +
  +
 **Default:** `10`
-
-|**FEATURE_LDAP_CACHING** |Boolean | enable in-memory caching for LDAP permission check results (superuser, restricted user). Reduces LDAP server load. +
- +
-**Default:** `False`
-
-|**LDAP_CACHE_TTL** |Integer | Time-to-live, in seconds, for cached LDAP permission results. +
- +
-**Default:** `60`
 |===
 
 .Basic LDAP configuration example YAML
@@ -102,8 +94,6 @@ LDAP_SECONDARY_USER_RDNS: <11>
     - ou=<example_organization_unit_two>
     - ou=<example_organization_unit_three>
     - ou=<example_organization_unit_four>
-FEATURE_LDAP_CACHING: true <12>
-LDAP_CACHE_TTL: 10  <13>
 ----
 <1> Required. Must be set to `LDAP`.
 <2> Required. The admin DN for LDAP authentication.
@@ -116,8 +106,6 @@ LDAP_CACHE_TTL: 10  <13>
 <9> Required. The user filter for LDAP authentication.
 <10> Required. The user RDN for LDAP authentication.
 <11> Optional. Secondary User Relative DNs if there are multiple Organizational Units where user objects are located.
-<12> Optional. Specifies whether to enable in-memory caching for LDAP permission check results (superuser, restricted user). Reduces LDAP server load. Defaults to `False`.
-<13> Specifies the time-to-live, in seconds, for cached LDAP permission results. Defaults to `60`. 
 
 .LDAP restricted user configuration example YAML
 [source,yaml]
@@ -144,8 +132,6 @@ LDAP_USER_RDN:
     - o=<organization_id>
     - dc=<example_domain_component>
     - dc=com
-FEATURE_LDAP_CACHING: true
-LDAP_CACHE_TTL: 10
 # ...
 ----
 <1> Must be set to `True` when configuring an LDAP restricted user.
@@ -174,8 +160,6 @@ LDAP_USER_RDN:
     - o=<organization_id>
     - dc=<example_domain_component>
     - dc=com
-FEATURE_LDAP_CACHING: true
-LDAP_CACHE_TTL: 10
 # ...
 ----
 <1> Configures specified users as superusers.

--- a/modules/proc_manage-ldap-setup.adoc
+++ b/modules/proc_manage-ldap-setup.adoc
@@ -127,8 +127,6 @@ LDAP_SECONDARY_USER_RDNS: <11>
     - ou=<example_organization_unit_two>
     - ou=<example_organization_unit_three>
     - ou=<example_organization_unit_four>
-FEATURE_LDAP_CACHING: true <12>
-LDAP_CACHE_TTL: 10 <13>
 # ...
 ----
 <1> Required. Must be set to `LDAP`.
@@ -142,8 +140,6 @@ LDAP_CACHE_TTL: 10 <13>
 <9> Required. The user filter for LDAP authentication.
 <10> Required. The user RDN for LDAP authentication.
 <11> Optional. Secondary User Relative DNs if there are multiple Organizational Units where user objects are located.
-<12> Optional. Specifies whether to enable in-memory caching for LDAP permission check results (superuser, restricted user). Reduces LDAP server load. Defaults to `False`.
-<13> Specifies the time-to-live, in seconds, for cached LDAP permission results. Defaults to `60`. 
 
 . After you have added all required LDAP fields, save the changes and restart your {productname} deployment.
 
@@ -187,8 +183,6 @@ LDAP_USER_RDN:
     - o=<organization_id>
     - dc=<example_domain_component>
     - dc=com
-FEATURE_LDAP_CACHING: true
-LDAP_CACHE_TTL: 10
 # ...
 ----
 <1> Must be set to `True` when configuring an LDAP restricted user.
@@ -236,8 +230,6 @@ LDAP_USER_RDN:
     - o=<organization_id>
     - dc=<example_domain_component>
     - dc=com
-FEATURE_LDAP_CACHING: true
-LDAP_CACHE_TTL: 10
 # ...
 ----
 <1> Configures specified users as superusers.


### PR DESCRIPTION
Reverts quay/quay-docs#1634