### PR TITLE
Adds 3.10.23 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.10
-:productminv: v3.10.22
+:productminv: v3.10.23
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -33,8 +33,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.10
-:productmin: 3.10.22
-:productminv: v3.10.22
+:productmin: 3.10.23
+:productminv: v3.10.23
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -4,6 +4,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+[id="rn-3-10-23"]
+== RHSA-2026:<xxxx> - {productname} 3.10.23 release
+
+Issued <YYYY-MM-DD>
+
+{productname} release 3.10.23 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:<xxxx>[RHSA-2026:<xxxx>] advisory.
+
+
 [id="rn-3-10-22"]
 == RHSA-2026:22840 - {productname} 3.10.22 release
 


### PR DESCRIPTION
## Summary
- Prepares z-stream release notes for Red Hat Quay 3.10.23
- Updates `productmin` / `productminv` to 3.10.23 in `modules/attributes.adoc`
- Source: https://github.com/quay/quay-konflux-configs/pull/213
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-11856

**Advisory-only release** (CVE-only fixes; no CCFR bug bullets):
- PROJQUAY-11671 (CVE-2026-48526) — skipped
- PROJQUAY-10888 (CVE-2026-32591) — skipped

## Pending before merge
- [ ] Konflux release PR merged: https://github.com/quay/quay-konflux-configs/pull/213
- [ ] Errata live on access.redhat.com (advisory ID + issued date)
- [ ] Add `modules/rn_3_10.adoc` section with real RHSA/RHBA link and issued date
- [ ] Remove draft status on this PR

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.10.23
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.10


Made with [Cursor](https://cursor.com)