### PR TITLE
Adds 3.10.23 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.10
-:productminv: v3.10.22
+:productminv: v3.10.23
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -33,8 +33,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.10
-:productmin: 3.10.22
-:productminv: v3.10.22
+:productmin: 3.10.23
+:productminv: v3.10.23
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -4,6 +4,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+[id="rn-3-10-23"]
+== RHSA-2026:33683 - {productname} 3.10.23 release
+
+Issued 2026-06-30
+
+{productname} release 3.10.23 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:33683[RHSA-2026:33683] advisory.
+
+
 [id="rn-3-10-22"]
 == RHSA-2026:22840 - {productname} 3.10.22 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.10.23
- Source: https://github.com/quay/quay-konflux-configs/pull/213
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12162

## Skipped (not documented)
All six fixed issues are CVE-only (PROJQUAY-11776, PROJQUAY-11728, PROJQUAY-11721, PROJQUAY-11671, PROJQUAY-11613, PROJQUAY-11592). Advisory-only entry per 3.10 y-stream convention.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:33683, issued 2026-06-30)
- [ ] Attributes updated to 3.10.23
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.10


Made with [Cursor](https://cursor.com)