### PR TITLE
Resolves 10437-projquay

### DIFF
--- a/api/master.adoc
+++ b/api/master.adoc
@@ -19,7 +19,8 @@ The following guide describes the {productname} API in more detail, and provides
 * Generating an OAuth 2 access token
 * Best practices for token management
 * OAuth 2 access token capabilities
-* Using the {productname} API 
+* Using the {productname} API
+* Programmatic OAuth token provisioning
 * {productname} API configuration examples
 
 This guide is accompanied with a second guide, link:https://docs.redhat.com/en/documentation/red_hat_quay/3.13/html/red_hat_quay_api_reference/index[{productname} API reference], that provides information about all `api/v1` endpoints and how to access those endpoints with example commands.
@@ -48,6 +49,7 @@ include::modules/using-the-api.adoc[leveloffset=+2]
 include::modules/configuring-api-calls.adoc[leveloffset=+2]
 include::modules/accessing-swagger-ui.adoc[leveloffset=+2]
 include::modules/automating-quay-using-the-api.adoc[leveloffset=+2]
+include::modules/programmatic-oauth-token-provisioning.adoc[leveloffset=+2]
 
 
 //API examples

--- a/api_reference/master.adoc
+++ b/api_reference/master.adoc
@@ -44,6 +44,8 @@ include::modules/api-build-getRepoBuilds.adoc[leveloffset=+2]
 include::modules/api-discovery.adoc[leveloffset=+1]
 include::modules/api-discovery-discovery.adoc[leveloffset=+2]
 
+include::modules/api-bootstrap-renewBootstrapToken.adoc[leveloffset=+1]
+
 //example procedures provided
 include::modules/api-error.adoc[leveloffset=+1]
 include::modules/api-error-getErrorDescription.adoc[leveloffset=+2]
@@ -122,6 +124,9 @@ include::modules/api-organization-getOrganizationApplication.adoc[leveloffset=+2
 include::modules/api-organization-updateOrganizationApplication.adoc[leveloffset=+2]
 include::modules/api-organization-deleteOrganizationApplication.adoc[leveloffset=+2]
 include::modules/api-organization-createOrganizationApplication.adoc[leveloffset=+2]
+include::modules/api-organization-createOrganizationApplicationToken.adoc[leveloffset=+2]
+include::modules/api-organization-listOrganizationApplicationTokens.adoc[leveloffset=+2]
+include::modules/api-organization-deleteOrganizationApplicationToken.adoc[leveloffset=+2]
 include::modules/api-organization-getOrganizationApplications.adoc[leveloffset=+2]
 include::modules/api-organization-getProxyCacheConfig.adoc[leveloffset=+2]
 include::modules/api-organization-deleteProxyCacheConfig.adoc[leveloffset=+2]

--- a/config_quay/master.adoc
+++ b/config_quay/master.adoc
@@ -123,6 +123,7 @@ include::modules/oidc-config-fields.adoc[leveloffset=+3]
 include::modules/config-fields-recaptcha.adoc[leveloffset=+3]
 include::modules/config-fields-jwt.adoc[leveloffset=+3]
 include::modules/config-fields-app-tokens.adoc[leveloffset=+3]
+include::modules/config-fields-programmatic-bootstrap.adoc[leveloffset=+3]
 
 //repository and namespace management
 include::modules/repo-namespace-configuration-overview.adoc[leveloffset=+2]

--- a/deploy_red_hat_quay_operator/master.adoc
+++ b/deploy_red_hat_quay_operator/master.adoc
@@ -51,6 +51,9 @@ include::modules/modifying-quayregistry-cr-cli.adoc[leveloffset=+2]
 include::modules/enabling-features-after-deployment.adoc[leveloffset=+1]
 include::modules/operator-config-cli.adoc[leveloffset=+2]
 include::modules/operator-config-cli-download.adoc[leveloffset=+2]
+include::modules/configuring-programmatic-bootstrap-ocp.adoc[leveloffset=+2]
+include::modules/reading-bootstrap-token.adoc[leveloffset=+3]
+include::modules/zero-touch-bootstrap-workflow.adoc[leveloffset=+3]
 
 //infrastructure deployment
 include::modules/operator-deploy-infrastructure.adoc[leveloffset=+1]

--- a/manage_quay/master.adoc
+++ b/manage_quay/master.adoc
@@ -9,8 +9,8 @@ After you deploy a {productname} registry, you can configure advanced settings, 
 The following topics are covered in this section:
 
 * Advanced {productname} configuration
-* Setting notifications to alert you of a new {productname} 
-release
+* Programmatic OAuth token provisioning
+* Setting notifications to alert you of a new {productname} release
 * Securing connections with SSL/TLS certificates
 * Directing action logs storage to Elasticsearch
 * Configuring image security scanning with Clair
@@ -31,6 +31,24 @@ include::modules/proc_manage-advanced-config.adoc[leveloffset=+1]
 include::modules/obtaining-configuration-information-quay.adoc[leveloffset=+2]
 
 include::modules/obtaining-configuration-information-quay-standalone.adoc[leveloffset=+2]
+
+include::modules/programmatic-oauth-token-provisioning.adoc[leveloffset=+1]
+include::modules/config-fields-programmatic-bootstrap.adoc[leveloffset=+2]
+include::modules/configuring-programmatic-bootstrap.adoc[leveloffset=+2]
+include::modules/reading-bootstrap-token.adoc[leveloffset=+2]
+include::modules/zero-touch-bootstrap-workflow.adoc[leveloffset=+2]
+include::modules/managing-oauth-application-tokens-api.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#createorganizationapplicationtoken[createOrganizationApplicationToken]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#listorganizationapplicationtokens[listOrganizationApplicationTokens]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#deleteorganizationapplicationtoken[deleteOrganizationApplicationToken]
+
+include::modules/renewing-bootstrap-token.adoc[leveloffset=+2]
+include::modules/revoking-bootstrap-token.adoc[leveloffset=+2]
+include::modules/programmatic-bootstrap-security.adoc[leveloffset=+2]
+include::modules/programmatic-bootstrap-troubleshooting.adoc[leveloffset=+2]
 
 include::modules/proc_manage-release-notifications.adoc[leveloffset=+1]
 

--- a/manage_quay/master.adoc
+++ b/manage_quay/master.adoc
@@ -35,6 +35,7 @@ include::modules/obtaining-configuration-information-quay-standalone.adoc[levelo
 include::modules/programmatic-oauth-token-provisioning.adoc[leveloffset=+1]
 include::modules/config-fields-programmatic-bootstrap.adoc[leveloffset=+2]
 include::modules/configuring-programmatic-bootstrap.adoc[leveloffset=+2]
+include::modules/configuring-programmatic-bootstrap-ocp.adoc[leveloffset=+2]
 include::modules/reading-bootstrap-token.adoc[leveloffset=+2]
 include::modules/zero-touch-bootstrap-workflow.adoc[leveloffset=+2]
 include::modules/managing-oauth-application-tokens-api.adoc[leveloffset=+2]

--- a/modules/api-bootstrap-renewBootstrapToken.adoc
+++ b/modules/api-bootstrap-renewBootstrapToken.adoc
@@ -1,0 +1,51 @@
+:_mod-docs-content-type: REFERENCE
+
+= renewBootstrapToken
+
+Rotate the programmatic bootstrap OAuth token.
+
+[discrete]
+== POST /api/v1/bootstrap/renew
+
+Renew the bootstrap token and write the new token value to `BOOTSTRAP_TOKEN_PATH` or the configured {kubernetes} Secret. The previous bootstrap token is invalidated immediately. The response does not include the new token value; read it from the configured storage location after renewal.
+
+This endpoint is available only when `FEATURE_PROGRAMMATIC_BOOTSTRAP` is `true`.
+
+**Authorizations:** Bearer token (bootstrap token)
+
+[discrete]
+== Request body
+
+No request body.
+
+[discrete]
+== Responses
+
+[options="header", width=100%, cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|200|Successful renewal|`{"status": "rotated"}`
+|401|Invalid, missing, or expired bootstrap token|&lt;&lt;_apierror,ApiError&gt;&gt;
+|403|Unauthorized access|&lt;&lt;_apierror,ApiError&gt;&gt;
+|===
+
+[NOTE]
+====
+When the bootstrap token is expired, renewal is accepted only from localhost. On {kubernetes} and {ocp}, use port forwarding and ensure the request includes the `X-Quay-Bootstrap-Renewal-Location: local` header set by the ingress layer.
+====
+
+[discrete]
+== Example command
+
+[source,terminal]
+----
+$ curl -X POST "https://<quay-server.example.com>/api/v1/bootstrap/renew" \
+  -H "Authorization: Bearer <bootstrap_token>"
+----
+
+.Example response
+
+[source,json]
+----
+{"status": "rotated"}
+----

--- a/modules/api-organization-createOrganizationApplicationToken.adoc
+++ b/modules/api-organization-createOrganizationApplicationToken.adoc
@@ -1,0 +1,93 @@
+:_mod-docs-content-type: REFERENCE
+
+= createOrganizationApplicationToken
+
+Create a new OAuth API token for the specified organization application.
+
+[discrete]
+== POST /api/v1/organization/{orgname}/applications/{client_id}/tokens
+
+Create a scoped OAuth API token for automation workflows. The bearer token secret is returned only in this response.
+
+**Authorizations:** oauth2_implicit (**org:admin**)
+
+[discrete]
+== Path parameters
+
+[options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|path|*orgname* +
+_required_|The name of the organization|string
+|path|*client_id* +
+_required_|The OAuth client ID of the organization application|string
+|===
+
+[discrete]
+== Request body schema (application/json)
+
+[options="header", width=100%, cols=".^3a,.^9a,.^4a"]
+|===
+|Name|Description|Schema
+|*name* +
+_required_|User-facing token name. Leading and trailing whitespace is trimmed before storage.|string
+|*scope* +
+_required_|Space- or comma-separated OAuth scope string, for example `repo:read repo:write`|string
+|*expiration* +
+_optional_|Token lifetime in seconds. Defaults to approximately 10 years when omitted.|integer
+|===
+
+.Example request body
+
+[source,json]
+----
+{
+  "name": "ci-job-token",
+  "scope": "repo:read,repo:write",
+  "expiration": 2592000
+}
+----
+
+[discrete]
+== Responses
+
+[options="header", width=100%, cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|200|Successful creation|OAuth application token object including `token`
+|400|Bad Request|&lt;&lt;_apierror,ApiError&gt;&gt;
+|401|Session required|&lt;&lt;_apierror,ApiError&gt;&gt;
+|403|Unauthorized access|&lt;&lt;_apierror,ApiError&gt;&gt;
+|404|Not found|&lt;&lt;_apierror,ApiError&gt;&gt;
+|===
+
+[discrete]
+== Example command
+
+[source,terminal]
+----
+$ curl -X POST "https://<quay-server.example.com>/api/v1/organization/<orgname>/applications/<client_id>/tokens" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ci-job-token",
+    "scope": "repo:read repo:write",
+    "expiration": 2592000
+  }'
+----
+
+.Example response
+
+[source,json]
+----
+{
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "name": "ci-job-token",
+  "scope": "repo:read repo:write",
+  "expires_at": "2026-08-14T10:00:00Z",
+  "created": "2026-07-15T10:00:00Z",
+  "created_by": "quayadmin",
+  "last_accessed": null,
+  "token": "string..."
+}
+----

--- a/modules/api-organization-deleteOrganizationApplicationToken.adoc
+++ b/modules/api-organization-deleteOrganizationApplicationToken.adoc
@@ -1,0 +1,45 @@
+:_mod-docs-content-type: REFERENCE
+
+= deleteOrganizationApplicationToken
+
+Revoke a specific OAuth API token for the specified organization application.
+
+[discrete]
+== DELETE /api/v1/organization/{orgname}/applications/{client_id}/tokens/{token_uuid}
+
+**Authorizations:** oauth2_implicit (**org:admin**)
+
+[discrete]
+== Path parameters
+
+[options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|path|*orgname* +
+_required_|The name of the organization|string
+|path|*client_id* +
+_required_|The OAuth client ID of the organization application|string
+|path|*token_uuid* +
+_required_|The UUID of the OAuth API token|string
+|===
+
+[discrete]
+== Responses
+
+[options="header", width=100%, cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|204|Successful revocation|No content
+|401|Session required|&lt;&lt;_apierror,ApiError&gt;&gt;
+|403|Unauthorized access|&lt;&lt;_apierror,ApiError&gt;&gt;
+|404|Not found|&lt;&lt;_apierror,ApiError&gt;&gt;
+|===
+
+[discrete]
+== Example command
+
+[source,terminal]
+----
+$ curl -X DELETE "https://<quay-server.example.com>/api/v1/organization/<orgname>/applications/<client_id>/tokens/<token_uuid>" \
+  -H "Authorization: Bearer <access_token>"
+----

--- a/modules/api-organization-listOrganizationApplicationTokens.adoc
+++ b/modules/api-organization-listOrganizationApplicationTokens.adoc
@@ -1,0 +1,75 @@
+:_mod-docs-content-type: REFERENCE
+
+= listOrganizationApplicationTokens
+
+List OAuth API tokens for the specified organization application.
+
+[discrete]
+== GET /api/v1/organization/{orgname}/applications/{client_id}/tokens
+
+Return token metadata for the specified application. The bearer token secret is not included in list responses.
+
+**Authorizations:** oauth2_implicit (**org:admin**)
+
+[discrete]
+== Path parameters
+
+[options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|path|*orgname* +
+_required_|The name of the organization|string
+|path|*client_id* +
+_required_|The OAuth client ID of the organization application|string
+|===
+
+[discrete]
+== Query parameters
+
+[options="header", width=100%, cols=".^3a,.^9a,.^4a"]
+|===
+|Name|Description|Schema
+|*next_page* +
+_optional_|Pagination token from a previous response|string
+|===
+
+[discrete]
+== Responses
+
+[options="header", width=100%, cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|200|Successful invocation|Object with `tokens` array and optional `next_page`
+|401|Session required|&lt;&lt;_apierror,ApiError&gt;&gt;
+|403|Unauthorized access|&lt;&lt;_apierror,ApiError&gt;&gt;
+|404|Not found|&lt;&lt;_apierror,ApiError&gt;&gt;
+|===
+
+[discrete]
+== Example command
+
+[source,terminal]
+----
+$ curl -X GET "https://<quay-server.example.com>/api/v1/organization/<orgname>/applications/<client_id>/tokens" \
+  -H "Authorization: Bearer <access_token>"
+----
+
+.Example response
+
+[source,json]
+----
+{
+  "tokens": [
+    {
+      "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "ci-job-token",
+      "scope": "repo:read repo:write",
+      "expires_at": "2026-08-14T10:00:00Z",
+      "created": "2026-07-15T10:00:00Z",
+      "created_by": "quayadmin",
+      "last_accessed": null
+    }
+  ],
+  "next_page": null
+}
+----

--- a/modules/config-fields-programmatic-bootstrap.adoc
+++ b/modules/config-fields-programmatic-bootstrap.adoc
@@ -3,7 +3,7 @@
 = Programmatic bootstrap configuration fields
 
 [role="_abstract"]
-Use these configuration fields to control filesystem-based bootstrap OAuth token provisioning for automated {productname} deployments. The feature remains disabled until you enable it.
+Use these configuration fields to control bootstrap OAuth token provisioning for automated {productname} deployments. The feature remains disabled until you enable it. Standalone deployments store the token in a local file. {productname-ocp} Operator deployments store the token in a Kubernetes Secret that the Operator creates and mounts.
 
 .Programmatic bootstrap fields
 [cols="3a,1a,2a",options="header"]
@@ -27,15 +27,15 @@ Use these configuration fields to control filesystem-based bootstrap OAuth token
 
 **Default:** `org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read`
 
-| **PROGRAMMATIC_TOKEN_K8S_SECRET** | String | {kubernetes} Secret name used to store the bootstrap token when {productname} runs in {kubernetes}. When set, {productname} writes the token to this Secret instead of `BOOTSTRAP_TOKEN_PATH`.
+| **PROGRAMMATIC_TOKEN_K8S_SECRET** | String | {kubernetes} Secret name used to store the bootstrap token when {productname} runs in {kubernetes}. When set, {productname} writes the token to this Secret instead of `BOOTSTRAP_TOKEN_PATH`. On {productname-ocp}, the Operator sets this field to `<quayregistry_name>-bootstrap-token` when programmatic bootstrap is enabled. Do not set this field manually in Operator-managed deployments.
 
-| **PROGRAMMATIC_TOKEN_K8S_KEY** | String | Secret data key that stores the bootstrap token JSON.
+| **PROGRAMMATIC_TOKEN_K8S_KEY** | String | Secret data key that stores the bootstrap token JSON. On {productname-ocp}, the Operator sets this field to `token.json`.
 
 **Default:** `token.json`
 
-| **PROGRAMMATIC_TOKEN_K8S_NAMESPACE** | String | {kubernetes} namespace that contains the bootstrap token Secret. When unset, {productname} uses the pod service account namespace.
+| **PROGRAMMATIC_TOKEN_K8S_NAMESPACE** | String | {kubernetes} namespace that contains the bootstrap token Secret. When unset, {productname} uses the pod service account namespace. On {productname-ocp}, the Operator uses the `QuayRegistry` namespace.
 
-| **PROGRAMMATIC_TOKEN_PATH** | String | Operator-rendered mount path accepted for configuration compatibility. {productname} uses `BOOTSTRAP_TOKEN_PATH` for local file storage.
+| **PROGRAMMATIC_TOKEN_PATH** | String | Operator-rendered mount path for configuration compatibility. On {productname-ocp}, the Operator sets this field to `/var/lib/quay/bootstrap-token/token.json`. Standalone deployments use `BOOTSTRAP_TOKEN_PATH` for local file storage.
 |===
 
 .Programmatic bootstrap example YAML (standalone)
@@ -47,22 +47,26 @@ SUPER_USERS:
 BOOTSTRAP_TOKEN_OWNER: quayadmin
 BOOTSTRAP_TOKEN_PATH: /var/lib/quay/quay-machine-token.json
 BOOTSTRAP_TOKEN_EXPIRATION: 7776000
-BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+BOOTSTRAP_TOKEN_SCOPE: "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"
 ----
 
-.Programmatic bootstrap example YAML ({ocp})
+.Programmatic bootstrap example YAML ({productname-ocp} `configBundleSecret`)
 [source,yaml]
 ----
 FEATURE_PROGRAMMATIC_BOOTSTRAP: true
 SUPER_USERS:
   - quayadmin
 BOOTSTRAP_TOKEN_OWNER: quayadmin
-PROGRAMMATIC_TOKEN_K8S_SECRET: quay-bootstrap-token
-PROGRAMMATIC_TOKEN_K8S_KEY: token.json
-PROGRAMMATIC_TOKEN_K8S_NAMESPACE: quay-enterprise
 BOOTSTRAP_TOKEN_EXPIRATION: 7776000
-BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+BOOTSTRAP_TOKEN_SCOPE: "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"
 ----
+
+[NOTE]
+====
+For Operator deployments, omit `BOOTSTRAP_TOKEN_PATH` and the `PROGRAMMATIC_TOKEN_K8S_*` fields from the `configBundleSecret`. The Operator injects `PROGRAMMATIC_TOKEN_K8S_SECRET`, `PROGRAMMATIC_TOKEN_K8S_KEY`, and `PROGRAMMATIC_TOKEN_PATH`, and creates the `<quayregistry_name>-bootstrap-token` Secret, Role, and RoleBinding automatically.
+
+Always quote `BOOTSTRAP_TOKEN_SCOPE`. Unquoted values that contain `:` can be misparsed by YAML.
+====
 
 [IMPORTANT]
 ====

--- a/modules/config-fields-programmatic-bootstrap.adoc
+++ b/modules/config-fields-programmatic-bootstrap.adoc
@@ -1,0 +1,72 @@
+:_mod-docs-content-type: REFERENCE
+[id="config-fields-programmatic-bootstrap"]
+= Programmatic bootstrap configuration fields
+
+[role="_abstract"]
+Use these configuration fields to control filesystem-based bootstrap OAuth token provisioning for automated {productname} deployments. The feature remains disabled until you enable it.
+
+.Programmatic bootstrap fields
+[cols="3a,1a,2a",options="header"]
+|===
+| Field | Type | Description
+| **FEATURE_PROGRAMMATIC_BOOTSTRAP** | Boolean | Enables programmatic bootstrap token provisioning. When `true`, {productname} creates a bootstrap OAuth token on startup and writes it to a local file or {kubernetes} Secret. When `false`, {productname} revokes any existing bootstrap token on restart.
+
+**Default:** `false`
+
+| **BOOTSTRAP_TOKEN_OWNER** | String | Username that owns the bootstrap OAuth application and token. Required when `FEATURE_PROGRAMMATIC_BOOTSTRAP` is `true`. The user must exist in the database and be listed in `SUPER_USERS`.
+
+| **BOOTSTRAP_TOKEN_PATH** | String | Filesystem path where the bootstrap token JSON is written on standalone and virtual machine deployments. In containerized deployments, use a mounted path that the {productname} process can write, for example `/datastorage/bootstrap-token.json`.
+
+**Default:** `/var/lib/quay/quay-machine-token.json`
+
+| **BOOTSTRAP_TOKEN_EXPIRATION** | Integer | Bootstrap token lifetime in seconds.
+
+**Default:** `3600` (60 minutes)
+
+| **BOOTSTRAP_TOKEN_SCOPE** | String | Space-separated OAuth scopes assigned to the bootstrap token.
+
+**Default:** `org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read`
+
+| **PROGRAMMATIC_TOKEN_K8S_SECRET** | String | {kubernetes} Secret name used to store the bootstrap token when {productname} runs in {kubernetes}. When set, {productname} writes the token to this Secret instead of `BOOTSTRAP_TOKEN_PATH`.
+
+| **PROGRAMMATIC_TOKEN_K8S_KEY** | String | Secret data key that stores the bootstrap token JSON.
+
+**Default:** `token.json`
+
+| **PROGRAMMATIC_TOKEN_K8S_NAMESPACE** | String | {kubernetes} namespace that contains the bootstrap token Secret. When unset, {productname} uses the pod service account namespace.
+
+| **PROGRAMMATIC_TOKEN_PATH** | String | Operator-rendered mount path accepted for configuration compatibility. {productname} uses `BOOTSTRAP_TOKEN_PATH` for local file storage.
+|===
+
+.Programmatic bootstrap example YAML (standalone)
+[source,yaml]
+----
+FEATURE_PROGRAMMATIC_BOOTSTRAP: true
+SUPER_USERS:
+  - quayadmin
+BOOTSTRAP_TOKEN_OWNER: quayadmin
+BOOTSTRAP_TOKEN_PATH: /var/lib/quay/quay-machine-token.json
+BOOTSTRAP_TOKEN_EXPIRATION: 7776000
+BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+----
+
+.Programmatic bootstrap example YAML ({ocp})
+[source,yaml]
+----
+FEATURE_PROGRAMMATIC_BOOTSTRAP: true
+SUPER_USERS:
+  - quayadmin
+BOOTSTRAP_TOKEN_OWNER: quayadmin
+PROGRAMMATIC_TOKEN_K8S_SECRET: quay-bootstrap-token
+PROGRAMMATIC_TOKEN_K8S_KEY: token.json
+PROGRAMMATIC_TOKEN_K8S_NAMESPACE: quay-enterprise
+BOOTSTRAP_TOKEN_EXPIRATION: 7776000
+BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+----
+
+[IMPORTANT]
+====
+The bootstrap token is a high-privilege credential. Use it only to provision organizations, applications, and narrower-scoped OAuth tokens for automation. Do not use the bootstrap token for routine API operations.
+
+For regulated environments, set `BOOTSTRAP_TOKEN_EXPIRATION` according to your token rotation policy and renew the token by using `POST /api/v1/bootstrap/renew`.
+====

--- a/modules/configuring-programmatic-bootstrap-ocp.adoc
+++ b/modules/configuring-programmatic-bootstrap-ocp.adoc
@@ -1,0 +1,115 @@
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-programmatic-bootstrap-ocp"]
+= Configuring programmatic bootstrap on {ocp}
+
+[role="_abstract"]
+To enable filesystem-independent bootstrap OAuth token provisioning for {productname-ocp}, you can add the programmatic bootstrap fields to the `configBundleSecret` resource. The {productname} Operator creates the bootstrap token Secret, Role, and RoleBinding, injects the Kubernetes storage fields, and restarts the Quay pods.
+
+[IMPORTANT]
+====
+Programmatic bootstrap token provisioning is a Tech Preview feature in {productname} {producty}. Tech Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using Tech Preview features in production environments. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+====
+
+.Prerequisites
+
+* You have deployed a {productname} registry on {ocp} by using the {productname} Operator.
+* You have created at least one superuser account. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#creating-first-user[Creating the first user].
+* You can edit the `configBundleSecret` resource that is referenced by your `QuayRegistry` custom resource (CR).
+
+.Procedure
+
+. Retrieve the name of the `configBundleSecret` resource:
++
+[source,terminal]
+----
+$ oc get quayregistry <quayregistry_name> -n <quay_namespace> \
+  -o jsonpath='{.spec.configBundleSecret}{"\n"}'
+----
++
+.Example output
+[source,terminal]
+----
+example-registry-config-bundle-abc12
+----
+
+. Export the current `config.yaml` file from the secret:
++
+[source,terminal]
+----
+$ oc get secret -n <quay_namespace> <config_bundle_secret_name> \
+  -o jsonpath='{.data.config\.yaml}' | base64 -d > config.yaml
+----
+
+. Edit `config.yaml` and add the programmatic bootstrap fields. For example:
++
+[source,yaml]
+----
+FEATURE_PROGRAMMATIC_BOOTSTRAP: true
+SUPER_USERS:
+  - quayadmin
+BOOTSTRAP_TOKEN_OWNER: quayadmin
+BOOTSTRAP_TOKEN_EXPIRATION: 7776000
+BOOTSTRAP_TOKEN_SCOPE: "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"
+----
++
+[IMPORTANT]
+====
+* `BOOTSTRAP_TOKEN_OWNER` must be an existing superuser that is also listed under `SUPER_USERS`.
+* Quote the `BOOTSTRAP_TOKEN_SCOPE` value. Unquoted scope strings that contain `:` can be misparsed by YAML.
+* Do not set `BOOTSTRAP_TOKEN_PATH` for Operator deployments. The Operator stores the token in a Kubernetes Secret.
+* You do not need to set `PROGRAMMATIC_TOKEN_K8S_SECRET`, `PROGRAMMATIC_TOKEN_K8S_KEY`, or `PROGRAMMATIC_TOKEN_K8S_NAMESPACE`. The Operator injects those values and creates the Secret named `<quayregistry_name>-bootstrap-token`.
+====
+
+. Create a new config bundle secret that includes the updated `config.yaml` file:
++
+[source,terminal]
+----
+$ oc create secret generic <new_config_bundle_secret_name> \
+  --from-file=config.yaml=./config.yaml \
+  -n <quay_namespace>
+----
+
+. Update the `QuayRegistry` CR to reference the new secret:
++
+[source,terminal]
+----
+$ oc patch quayregistry <quayregistry_name> -n <quay_namespace> \
+  --type=merge -p '{"spec":{"configBundleSecret":"<new_config_bundle_secret_name>"}}'
+----
++
+The Operator reconciles the change, creates the `<quayregistry_name>-bootstrap-token` Secret with accompanying Role and RoleBinding resources, mounts the Secret into the Quay application pods, and restarts Quay-related pods.
+
+. Wait for the Quay application pods to become ready:
++
+[source,terminal]
+----
+$ oc get pods -n <quay_namespace> -l quay-component=quay-app
+----
+
+. Verify that the Operator created the bootstrap token Secret:
++
+[source,terminal]
+----
+$ oc get secret <quayregistry_name>-bootstrap-token -n <quay_namespace>
+----
+
+. Read the bootstrap token from the Secret:
++
+[source,terminal]
+----
+$ BOOTSTRAP_TOKEN=$(oc get secret <quayregistry_name>-bootstrap-token -n <quay_namespace> \
+  -o jsonpath='{.data.token\.json}' | base64 -d | jq -r '.access_token')
+----
++
+[NOTE]
+====
+Secret propagation can take up to 60 seconds after the Quay pods start. If `token.json` is missing, wait and retry the command.
+====
+
+. Optional. Confirm that Quay startup logs include a bootstrap provisioning message:
++
+[source,terminal]
+----
+$ oc logs -n <quay_namespace> deploy/<quayregistry_name>-quay-app -c quay-app \
+  | grep -i 'bootstrap token'
+----

--- a/modules/configuring-programmatic-bootstrap.adoc
+++ b/modules/configuring-programmatic-bootstrap.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-programmatic-bootstrap"]
+= Configuring programmatic bootstrap
+
+[role="_abstract"]
+To configure filesystem-based bootstrap OAuth token provisioning in {productname}, you can set `FEATURE_PROGRAMMATIC_BOOTSTRAP` and related fields, then restart the registry.
+
+.Prerequisites
+
+* You have a {productname} deployment with at least one superuser account created.
+* You can modify the {productname} configuration file or Operator `configBundleSecret` resource.
+
+.Procedure
+
+. Set the following fields in your {productname} `config.yaml` file:
++
+[source,yaml]
+----
+FEATURE_PROGRAMMATIC_BOOTSTRAP: true
+SUPER_USERS:
+  - quayadmin
+BOOTSTRAP_TOKEN_OWNER: quayadmin
+BOOTSTRAP_TOKEN_EXPIRATION: 7776000
+BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+BOOTSTRAP_TOKEN_PATH: /datastorage/bootstrap-token.json
+----
++
+* For standalone deployments, set `BOOTSTRAP_TOKEN_PATH` to a directory that the {productname} process can write. In containerized deployments, use a mounted storage path such as `/datastorage/bootstrap-token.json`.
++
+* For {kubernetes} and {ocp} deployments, set `PROGRAMMATIC_TOKEN_K8S_SECRET` and related fields.
+
+. Restart {productname} after you update the configuration.
++
+[NOTE]
+====
+If you enable `FEATURE_PROGRAMMATIC_BOOTSTRAP` on a deployment that is already running, you must restart {productname} so the bootstrap token is provisioned and the `POST /api/v1/bootstrap/renew` endpoint is registered. A full restart is required; reloading configuration without restarting does not register the bootstrap API endpoints.
+====
+
+. Verify bootstrap provisioning:
++
+.. Check {productname} startup logs for a `Bootstrap token provisioned` message.
++
+.. Confirm that the bootstrap token file or {kubernetes} Secret exists at the configured storage location. For example, on a standalone deployment:
++
+[source,terminal]
+----
+$ ls -l <BOOTSTRAP_TOKEN_PATH>
+----

--- a/modules/configuring-programmatic-bootstrap.adoc
+++ b/modules/configuring-programmatic-bootstrap.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-programmatic-bootstrap"]
-= Configuring programmatic bootstrap
+= Configuring programmatic bootstrap on standalone deployments
 
 [role="_abstract"]
-To configure filesystem-based bootstrap OAuth token provisioning in {productname}, you can set `FEATURE_PROGRAMMATIC_BOOTSTRAP` and related fields, then restart the registry.
+To configure filesystem-based bootstrap OAuth token provisioning in a standalone {productname} deployment, you can set `FEATURE_PROGRAMMATIC_BOOTSTRAP` and related fields in the `config.yaml` file, then restart the registry.
 
 .Prerequisites
 
-* You have a {productname} deployment with at least one superuser account created.
-* You can modify the {productname} configuration file or Operator `configBundleSecret` resource.
+* You have a standalone {productname} deployment with at least one superuser account created.
+* You can modify the {productname} `config.yaml` file.
 
 .Procedure
 
@@ -21,13 +21,11 @@ SUPER_USERS:
   - quayadmin
 BOOTSTRAP_TOKEN_OWNER: quayadmin
 BOOTSTRAP_TOKEN_EXPIRATION: 7776000
-BOOTSTRAP_TOKEN_SCOPE: org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read
+BOOTSTRAP_TOKEN_SCOPE: "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"
 BOOTSTRAP_TOKEN_PATH: /datastorage/bootstrap-token.json
 ----
 +
-* For standalone deployments, set `BOOTSTRAP_TOKEN_PATH` to a directory that the {productname} process can write. In containerized deployments, use a mounted storage path such as `/datastorage/bootstrap-token.json`.
-+
-* For {kubernetes} and {ocp} deployments, set `PROGRAMMATIC_TOKEN_K8S_SECRET` and related fields.
+Set `BOOTSTRAP_TOKEN_PATH` to a directory that the {productname} process can write. In containerized standalone deployments, use a mounted storage path such as `/datastorage/bootstrap-token.json`. Quote the `BOOTSTRAP_TOKEN_SCOPE` value so YAML does not misparse scopes that contain `:`.
 
 . Restart {productname} after you update the configuration.
 +
@@ -40,7 +38,7 @@ If you enable `FEATURE_PROGRAMMATIC_BOOTSTRAP` on a deployment that is already r
 +
 .. Check {productname} startup logs for a `Bootstrap token provisioned` message.
 +
-.. Confirm that the bootstrap token file or {kubernetes} Secret exists at the configured storage location. For example, on a standalone deployment:
+.. Confirm that the bootstrap token file exists at the configured storage location. For example:
 +
 [source,terminal]
 ----

--- a/modules/managing-oauth-application-tokens-api.adoc
+++ b/modules/managing-oauth-application-tokens-api.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: PROCEDURE
+[id="managing-oauth-application-tokens-api"]
+= Managing OAuth application tokens by using the API
+
+[role="_abstract"]
+To manage organization application OAuth tokens without using the UI, you can list, create, and revoke tokens through the {productname} REST API when your token has `org:admin` scope.
+
+The bootstrap token includes `org:admin` by default. Scoped tokens that you create for automation must also include `org:admin` to list, create, or revoke application tokens through these endpoints.
+
+.Procedure
+
+. List existing tokens for an application:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer <access_token>" -X GET \
+  https://<quay-server.example.com>/api/v1/organization/myorg/applications/<client_id>/tokens
+----
+
+. Create a token with a custom expiration and scope:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer <access_token>" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"name": "short-lived-token", "scope": "repo:read", "expiration": 3600}' \
+  https://<quay-server.example.com>/api/v1/organization/myorg/applications/<client_id>/tokens
+----
+
+. Revoke a token by UUID:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer <access_token>" -X DELETE \
+  https://<quay-server.example.com>/api/v1/organization/myorg/applications/<client_id>/tokens/<token_uuid>
+----

--- a/modules/new-api-endpoints-318.adoc
+++ b/modules/new-api-endpoints-318.adoc
@@ -13,3 +13,27 @@ Robot federation configuration entries now support an optional `audiences` array
 A future release will require the `audiences` field for federated robot authentication.
 
 Configure federation entries by using the {productname} v2 UI or `POST /api/v1/organization/{orgname}/robots/{robot_shortname}/federation`. In {productname} 3.18, create and update requests persist `issuer` and `subject` only; audience validation applies when `audiences` is present in the stored federation configuration. For field descriptions, examples, and current API limitations, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#createorgrobotfederation[createOrgRobotFederation] and link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/use_red_hat_quay/index#configuring-federation-audiences[Configuring federation audiences].
+
+[id="organization-application-token-api-318"]
+== Organization application OAuth token lifecycle
+
+{productname} 3.18 adds REST API endpoints to manage OAuth API tokens for organization applications:
+
+[cols="1a,3a,2a",options="header"]
+|===
+|Method |Endpoint |Description
+|`POST` |`/api/v1/organization/{orgname}/applications/{client_id}/tokens` |Create a token
+|`GET` |`/api/v1/organization/{orgname}/applications/{client_id}/tokens` |List token metadata
+|`DELETE` |`/api/v1/organization/{orgname}/applications/{client_id}/tokens/{token_uuid}` |Revoke a token
+|===
+
+Create requests accept `name`, `scope`, and optional `expiration` (seconds). The bearer token secret is returned only in the create response.
+
+For API schemas and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#createorganizationapplicationtoken[createOrganizationApplicationToken], link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#listorganizationapplicationtokens[listOrganizationApplicationTokens], and link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#deleteorganizationapplicationtoken[deleteOrganizationApplicationToken].
+
+[id="bootstrap-token-renewal-api-318"]
+== Bootstrap token renewal
+
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, `POST /api/v1/bootstrap/renew` rotates the bootstrap OAuth token. The new token is written to the configured filesystem path or {kubernetes} Secret, and the previous token is invalidated immediately. The response is `{"status": "rotated"}`.
+
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#renewbootstraptoken[renewBootstrapToken] and link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#renewing-bootstrap-token[Renewing the bootstrap token].

--- a/modules/new-features-and-enhancements-318.adoc
+++ b/modules/new-features-and-enhancements-318.adoc
@@ -17,3 +17,14 @@ This enhancement enables integrations with Red Hat Developer Hub (RHDH), Red Hat
 Federated robot authentication also supports an optional `audiences` array on each federation configuration entry. When configured, {productname} validates the external OIDC token audience during robot token exchange. When absent, audience validation is skipped and a deprecation warning is logged. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/release_notes/index#robot-federation-audiences-318[Robot federation `audiences` field].
 
 For configuration field descriptions, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/release_notes/index#oidc-multi-issuer-config-fields-318[OIDC multi-issuer configuration fields]. For setup and migration procedures, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC].
+
+[id="programmatic-oauth-token-provisioning-318"]
+== Programmatic OAuth token provisioning (Tech Preview)
+
+{productname} 3.18 introduces programmatic OAuth API token lifecycle management for organization applications. You can create, list, and revoke OAuth API tokens by using the REST API instead of the UI.
+
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} can also auto-generate a high-privilege bootstrap OAuth token on startup and write it to a local file or {kubernetes} Secret. Use this bootstrap token for zero-touch automation workflows such as GitOps-based deployments, CI/CD bootstrap, and headless registry provisioning.
+
+This feature is available as Tech Preview in {productname} 3.18.
+
+For configuration fields, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/release_notes/index#programmatic-bootstrap-config-fields-318[Programmatic bootstrap configuration fields]. For setup and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#programmatic-oauth-token-provisioning[Programmatic OAuth token provisioning].

--- a/modules/new-quay-config-fields-318.adoc
+++ b/modules/new-quay-config-fields-318.adoc
@@ -55,3 +55,23 @@ The following fields apply to the `tls` entry in `spec.components` of the `QuayR
 |===
 
 For procedures and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#operator-external-tls-secret-reference[Referencing an external TLS Secret for {productname-ocp}].
+
+[id="programmatic-bootstrap-config-fields-318"]
+== Programmatic bootstrap configuration fields
+
+{productname} 3.18 adds configuration fields for Tech Preview programmatic bootstrap OAuth token provisioning:
+
+[cols="2a,1a,3a",options="header"]
+|===
+|Field |Type |Description
+|`FEATURE_PROGRAMMATIC_BOOTSTRAP` |Boolean |Enables bootstrap token auto-generation on startup. Default: `false`.
+|`BOOTSTRAP_TOKEN_OWNER` |String |Superuser that owns the bootstrap OAuth application and token. Required when the feature flag is enabled.
+|`BOOTSTRAP_TOKEN_PATH` |String |Local filesystem path for the bootstrap token JSON. Default: `/var/lib/quay/quay-machine-token.json`.
+|`BOOTSTRAP_TOKEN_EXPIRATION` |Integer |Bootstrap token lifetime in seconds. Default: `3600`.
+|`BOOTSTRAP_TOKEN_SCOPE` |String |Space-separated OAuth scopes for the bootstrap token.
+|`PROGRAMMATIC_TOKEN_K8S_SECRET` |String |{kubernetes} Secret name for bootstrap token storage.
+|`PROGRAMMATIC_TOKEN_K8S_KEY` |String |Secret data key for the bootstrap token JSON. Default: `token.json`.
+|`PROGRAMMATIC_TOKEN_K8S_NAMESPACE` |String |Namespace for the bootstrap token Secret.
+|===
+
+For descriptions and YAML examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/configure_red_hat_quay/index#config-fields-programmatic-bootstrap[Programmatic bootstrap configuration fields].

--- a/modules/oauth2-access-tokens.adoc
+++ b/modules/oauth2-access-tokens.adoc
@@ -9,7 +9,7 @@ link:https://oauth.net/2/[OAuth 2] access tokens (considered "API tokens" for {p
 Although OAuth 2 tokens authorize actions on API endpoints based on the scopes defined for the token, access to the resources themselves is governed by {productname}'s role-based access control (RBAC) mechanisms. Actions can be created on a resource, for example, a repository, provided that you have the proper role (*Admin* or *Creator*) to do so for that namespace. This is true even if the API token was granted the `repo:admin` scope.
 ====
 
-OAuth 2 access tokens can only be created by using the {productname} UI; there is no way to create an OAuth 2 access token by using the CLI. When creating an OAuth 2 token, the following options can be selected for a token holder:
+OAuth 2 access tokens can be created by using the {productname} UI or by using the organization application token API. When creating an OAuth 2 token, the following options can be selected for a token holder:
 
 * *Administer Organization*. When selected, allows the user to be able to administer organizations, including creating robots, creating teams, adjusting team membership, and changing billing settings.
 
@@ -33,11 +33,16 @@ OAuth 2 access tokens are passed as a `Bearer` token in the `Authorization` head
 
 The API is available from the `/api/v1` endpoint of your {productname} host. For example, `\https://<quay-server.example.com>/api/v1`. It allows users to connect to endpoints through their browser to `GET`, `POST`, `DELETE`, and `PUT` {productname} settings by enabling the Swagger UI. The API can be accessed by applications that make API calls and use OAuth tokens, and it sends and receives data as JSON. 
 
-With {productname}, there is currently no way to rotate or to set an expiration time on an OAuth 2 access token, and the token lifespan is 10 years. Tokens can be deleted by deleting the applications in which they were created in the event that they are compromised, however, this deletes all tokens that were made within that specific application.
+With {productname}, organization application OAuth API tokens created through the UI do not support custom expiration and default to approximately 10 years. Tokens created by using the organization application token API support custom `expiration` values in seconds. Tokens can be revoked individually by using the API or by deleting the application in which they were created. Deleting an application revokes all tokens created within that application.
 
 [NOTE]
 ====
-In practice, {productname} administrators _could_ create a new OAuth application on the *Applications* page of their organization each time they wanted to create a new OAuth token for a user. This would ensure that a single application is not responsible for all OAuth tokens. As a result, in the event that a user's token is compromised, the administrator would delete the application of the compromised token. This would help avoid disruption for other users whose tokens might be part of the same application. 
+For programmatic token creation, listing, and revocation, see "Programmatic OAuth token provisioning".
+====
+
+[NOTE]
+====
+In practice, {productname} administrators _could_ create a new OAuth application on the *Applications* page of their organization each time they wanted to create a new OAuth token for a user. This would ensure that a single application is not responsible for all OAuth tokens. As a result, in the event that a user's token is compromised, the administrator would delete the application of the compromised token. This would help avoid disruption for other users whose tokens might be part of the same application.
 ====
 
 The following sections shows you how to generate and reassign an OAuth 2 access token.

--- a/modules/org-application-create-api.adoc
+++ b/modules/org-application-create-api.adoc
@@ -6,12 +6,7 @@
 [id="org-application-create-api"]
 = Creating an organization application by using the {productname} API
 
-Organization applications can be created by using the {productname} UI. 
-
-[NOTE]
-====
-Organization applications can be created by using the UI, however OAuth 2 access tokens must be created on the UI.
-====
+Organization applications can be created by using the {productname} UI or API. Starting in {productname} {producty}, you can also create, list, and revoke OAuth API tokens for organization applications by using the API.
 
 .Procedure
 

--- a/modules/programmatic-bootstrap-security.adoc
+++ b/modules/programmatic-bootstrap-security.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: CONCEPT
+[id="programmatic-bootstrap-security"]
+= Security considerations for programmatic bootstrap
+
+[role="_abstract"]
+Apply these practices when you use the {productname} bootstrap OAuth token so that automation remains limited to provisioning and uses narrower-scoped tokens for day-to-day work.
+
+* Use the bootstrap token only for initial provisioning and token minting. Create narrower-scoped OAuth tokens for CI/CD and day-2 automation.
+
+* Set `BOOTSTRAP_TOKEN_EXPIRATION` according to your security policy. The default is 60 minutes.
+
+* On standalone deployments, the bootstrap token file is written with `0600` permissions. Restrict access to the directory that contains the token file.
+
+* On {kubernetes} and {ocp}, store the bootstrap token in a dedicated Secret with scoped RBAC.
+
+* Schedule bootstrap token renewal by using `POST /api/v1/bootstrap/renew` before expiry.
+
+* Monitor {productname} action logs for bootstrap and OAuth token life cycle events.

--- a/modules/programmatic-bootstrap-troubleshooting.adoc
+++ b/modules/programmatic-bootstrap-troubleshooting.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: CONCEPT
+[id="programmatic-bootstrap-troubleshooting"]
+= Troubleshooting programmatic bootstrap
+
+[role="_abstract"]
+Use these checks when programmatic bootstrap token provisioning fails in {productname}, including missing token files, authorization errors, and renewal failures.
+
+If the token file or Secret is empty after startup:
+
+* Verify that `FEATURE_PROGRAMMATIC_BOOTSTRAP` is `true`.
+
+* Verify that `BOOTSTRAP_TOKEN_OWNER` is set and listed in `SUPER_USERS`.
+
+* Verify that the bootstrap token owner exists in the {productname} database.
+
+* Check {productname} startup logs for bootstrap provisioning errors.
+
+* If the bootstrap token file or Secret is still missing after the first restart, restart {productname} again or run `python3 /quay-registry/boot.py` inside the {productname} container after confirming `BOOTSTRAP_TOKEN_OWNER` exists in the database.
+
+If you receive `403 Forbidden` when using the bootstrap token:
+
+* Confirm that the token has not expired.
+
+* Confirm that bootstrap provisioning was not disabled and the token revoked.
+
+* Confirm that the target API endpoint is authorized by the bootstrap token scope.
+
+If renewal returns `401 Unauthorized`:
+
+* If the token is expired, send the renewal request from localhost or through a port-forwarded local ingress path.
+
+* Confirm that you are passing the bootstrap token value, not a different OAuth token.
+
+If rate limiting returns `429 Too Many Requests`:
+
+* Bootstrap and token management endpoints are subject to existing rate limiting when `FEATURE_RATE_LIMITS` is enabled. Adjust request frequency or review your rate limit configuration.

--- a/modules/programmatic-bootstrap-troubleshooting.adoc
+++ b/modules/programmatic-bootstrap-troubleshooting.adoc
@@ -17,6 +17,10 @@ If the token file or Secret is empty after startup:
 
 * If the bootstrap token file or Secret is still missing after the first restart, restart {productname} again or run `python3 /quay-registry/boot.py` inside the {productname} container after confirming `BOOTSTRAP_TOKEN_OWNER` exists in the database.
 
+* On {productname-ocp}, confirm that the Operator created the `<quayregistry_name>-bootstrap-token` Secret, Role, and RoleBinding, and that Quay application pods have rolled out with the updated `configBundleSecret`. An empty Secret before the pods restart is expected; the Quay process writes `token.json` after startup.
+
+* Confirm that `BOOTSTRAP_TOKEN_SCOPE` is a quoted YAML string. Unquoted scope values that contain `:` can be misparsed.
+
 If you receive `403 Forbidden` when using the bootstrap token:
 
 * Confirm that the token has not expired.

--- a/modules/programmatic-oauth-token-provisioning.adoc
+++ b/modules/programmatic-oauth-token-provisioning.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: CONCEPT
+[id="programmatic-oauth-token-provisioning"]
+= Programmatic OAuth token provisioning
+
+[role="_abstract"]
+Programmatic OAuth token provisioning in {productname} lets you create and manage organization application tokens through the REST API. You can also enable a Tech Preview bootstrap token for zero-touch automation without using the UI.
+
+Organization OAuth applications previously required administrators to create API tokens in the {productname} UI. With programmatic token provisioning, automation tools can manage the token life cycle.
+
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} also creates a high-privilege bootstrap OAuth token on startup and writes it to a local file or {kubernetes} Secret. Use the bootstrap token to create organizations, applications, and narrower-scoped tokens without interactive UI access.
+
+[IMPORTANT]
+====
+Programmatic bootstrap token provisioning is a Tech Preview feature in {productname} {producty}. Tech Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using Tech Preview features in production environments. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]

--- a/modules/reading-bootstrap-token.adoc
+++ b/modules/reading-bootstrap-token.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: PROCEDURE
+[id="reading-bootstrap-token"]
+= Reading the bootstrap token
+
+[role="_abstract"]
+To obtain the bootstrap OAuth token after {productname} starts with programmatic bootstrap enabled, you can read the token from the configured local file or {kubernetes} Secret.
+
+.Procedure
+
+. For standalone or virtual machine deployments, read the token from the `BOOTSTRAP_TOKEN_PATH` file:
++
+[source,terminal]
+----
+$ BOOTSTRAP_TOKEN=$(jq -r '.access_token' /var/lib/quay/quay-machine-token.json)
+----
++
+[NOTE]
+====
+{productname} writes the bootstrap token file with `0600` permissions owned by the {productname} process user. If you cannot read the file from the host, read it from inside the {productname} container instead. For example:
++
+[source,terminal]
+----
+$ BOOTSTRAP_TOKEN=$(docker exec quay cat /datastorage/bootstrap-token.json | jq -r '.access_token')
+----
+====
+
+. For {kubernetes} and {ocp} deployments, read the token from the configured {kubernetes} Secret:
++
+[source,terminal]
+----
+$ BOOTSTRAP_TOKEN=$(oc get secret quay-bootstrap-token -n quay-enterprise \
+  -o jsonpath='{.data.token\.json}' | base64 -d | jq -r '.access_token')
+----
++
+[NOTE]
+====
+{kubernetes} Secret propagation can take up to 60 seconds after renewal or initial provisioning. Verify that the Secret mount path matches your Operator configuration.
+====

--- a/modules/reading-bootstrap-token.adoc
+++ b/modules/reading-bootstrap-token.adoc
@@ -24,15 +24,22 @@ $ BOOTSTRAP_TOKEN=$(docker exec quay cat /datastorage/bootstrap-token.json | jq 
 ----
 ====
 
-. For {kubernetes} and {ocp} deployments, read the token from the configured {kubernetes} Secret:
+. For {productname-ocp} Operator deployments, read the token from the Operator-managed Secret. The Secret name is `<quayregistry_name>-bootstrap-token`:
 +
 [source,terminal]
 ----
-$ BOOTSTRAP_TOKEN=$(oc get secret quay-bootstrap-token -n quay-enterprise \
+$ BOOTSTRAP_TOKEN=$(oc get secret <quayregistry_name>-bootstrap-token -n <quay_namespace> \
+  -o jsonpath='{.data.token\.json}' | base64 -d | jq -r '.access_token')
+----
++
+.Example
+[source,terminal]
+----
+$ BOOTSTRAP_TOKEN=$(oc get secret example-registry-bootstrap-token -n quay-operator \
   -o jsonpath='{.data.token\.json}' | base64 -d | jq -r '.access_token')
 ----
 +
 [NOTE]
 ====
-{kubernetes} Secret propagation can take up to 60 seconds after renewal or initial provisioning. Verify that the Secret mount path matches your Operator configuration.
+{kubernetes} Secret propagation can take up to 60 seconds after renewal or initial provisioning. If the `token.json` key is missing, wait for the Quay application pods to finish starting and retry the command.
 ====

--- a/modules/renewing-bootstrap-token.adoc
+++ b/modules/renewing-bootstrap-token.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: PROCEDURE
+[id="renewing-bootstrap-token"]
+= Renewing the bootstrap token
+
+[role="_abstract"]
+To keep automation running when the bootstrap OAuth token approaches expiry, you can renew it through the {productname} REST API before the previous token is invalidated.
+
+.Procedure
+
+. Renew the token by using the bootstrap token as Bearer authentication:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $BOOTSTRAP_TOKEN" -X POST \
+  https://<quay-server.example.com>/api/v1/bootstrap/renew
+----
++
+The following example shows a successful response:
++
+[source,json]
+----
+{"status": "rotated"}
+----
+
+. Read the new token value from `BOOTSTRAP_TOKEN_PATH` or the configured {kubernetes} Secret. The previous bootstrap token is invalidated immediately.
++
+[NOTE]
+====
+If the bootstrap token is already expired, renewal is accepted only from localhost. On {kubernetes} and {ocp}, use port forwarding to send the renewal request through the local ingress path.
+====

--- a/modules/revoking-bootstrap-token.adoc
+++ b/modules/revoking-bootstrap-token.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: CONCEPT
+[id="revoking-bootstrap-token"]
+= Revoking the bootstrap token
+
+[role="_abstract"]
+You can revoke the {productname} bootstrap OAuth token by disabling `FEATURE_PROGRAMMATIC_BOOTSTRAP` and restarting the registry. {productname} does not provide a separate API endpoint for instant revocation.
+
+To revoke the bootstrap token, set `FEATURE_PROGRAMMATIC_BOOTSTRAP: false` and restart {productname}. {productname} deletes bootstrap-managed applications and tokens during startup.

--- a/modules/zero-touch-bootstrap-workflow.adoc
+++ b/modules/zero-touch-bootstrap-workflow.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: PROCEDURE
+[id="zero-touch-bootstrap-workflow"]
+= Using the bootstrap token for zero-touch deployment
+
+[role="_abstract"]
+To provision {productname} resources without using the UI, you can use the bootstrap OAuth token as Bearer authentication for organization, application, and token API calls.
+
+.Procedure
+
+. Export the bootstrap token. For example:
++
+[source,terminal]
+----
+$ export BOOTSTRAP_TOKEN=<bootstrap_token_value>
+----
+
+. Create an organization:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $BOOTSTRAP_TOKEN" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"name": "myorg", "email": "admin@example.com"}' \
+  https://<quay-server.example.com>/api/v1/organization/
+----
+
+. Create an OAuth application in the organization:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $BOOTSTRAP_TOKEN" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ci-automation", "description": "CI/CD token source"}' \
+  https://<quay-server.example.com>/api/v1/organization/myorg/applications
+----
+
+. Create a scoped OAuth API token for the application:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $BOOTSTRAP_TOKEN" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ci-job-token", "scope": "repo:read repo:write", "expiration": 2592000}' \
+  https://<quay-server.example.com>/api/v1/organization/myorg/applications/<client_id>/tokens
+----
+
+. Store the `token` value from the response for your automation workflow. The token secret is returned only in the create response.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/PROJQUAY-10437

PREVIEW: https://quay-docs-pr-1695.surge.sh/api_quay.html#programmatic-oauth-token-provisioning
https://quay-docs-pr-1695.surge.sh/manage_quay.html#programmatic-oauth-token-provisioning
https://quay-docs-pr-1695.surge.sh/api_reference.html#:~:text=Rotate%20the%20programmatic%20bootstrap%20OAuth%20token.