### PR TITLE
Fix 1681 org contact email docs for Quay 3.18

### DIFF
--- a/api/master.adoc
+++ b/api/master.adoc
@@ -3,6 +3,7 @@ include::_attributes/attributes.adoc[][id="api"]
 = {productname} API guide
 :context: use-api
 
+[role="_abstract"]
 The {productname} application programming interface (API) provides a comprehensive, RESTful interface for managing and automating tasks within {productname}. Designed around the link:https://oauth.net/2/[_OAuth 2.0 protocol_], this API enables secure, fine-grained access to {productname} resources, and allows administrators and users to perform such actions as creating repositories, managing images, setting permissions, and more. 
 
 {productname} follows Semantic Versioning (SemVer) principles, ensuring predictable API stability across releases, such as:
@@ -22,7 +23,12 @@ The following guide describes the {productname} API in more detail, and provides
 * Using the {productname} API 
 * {productname} API configuration examples
 
-This guide is accompanied with a second guide, link:https://docs.redhat.com/en/documentation/red_hat_quay/3.13/html/red_hat_quay_api_reference/index[{productname} API reference], that provides information about all `api/v1` endpoints and how to access those endpoints with example commands.
+The guide is accompanied with a second guide, _{productname} API reference_, that provides information about all `api/v1` endpoints and how to access those endpoints with example commands.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.13/html/red_hat_quay_api_reference/index[{productname} API reference]
 
 //overview
 include::modules/token-overview.adoc[leveloffset=+1]
@@ -81,6 +87,7 @@ include::modules/organization-management-api.adoc[leveloffset=+2]
 //org creation
 include::modules/org-create-api.adoc[leveloffset=+3]
 include::modules/org-delete-api.adoc[leveloffset=+3]
+include::modules/org-contact-email-api.adoc[leveloffset=+3]
 //member management
 include::modules/org-team-member-api.adoc[leveloffset=+3]
 //application

--- a/modules/org-contact-email-api.adoc
+++ b/modules/org-contact-email-api.adoc
@@ -7,24 +7,28 @@
 = Managing organization contact email with the API
 
 [role="_abstract"]
-Use the `contact_email` field to configure where automated system alerts are sent for an organization. This field is decoupled from user account identities, allowing multiple organizations to share the same email address without authentication conflicts.
+Use the `contact_email` request field (or the legacy `email` field) to set where automated system alerts are sent for an organization. Multiple organizations can share the same address, which is useful for team distribution lists.
 
-The `contact_email` field has the following properties:
+The organization contact email has the following properties:
 
 * Receives automated notifications including quota warnings, security alerts, and build failures
-* Can be shared across multiple organizations (useful for team distribution lists)
-* An optional field so if not set, notifications default to organization owners
-* Does not enforce global uniqueness constraints
+* Can be shared across multiple organizations
+* Is optional on create when mailing is not required; if not set, notifications default to organization owners
+* Is accepted on create and update as `contact_email` or `email`; {productname} stores and returns the value in the `email` response field
 
 [NOTE]
 ====
-Before the `contact_email` field, organizations were forced to use unique dummy email addresses to avoid account collision errors. This resulted in undelivered notifications. Always use a real, monitored email address for the `contact_email` field.
+By default, an organization cannot use an email address that is already assigned to a user account. To allow organizations to share an email address with a user account, set `FEATURE_ORG_SHARED_EMAIL: true` in your {productname} configuration. Organization-to-organization sharing works without that flag.
+====
+
+[NOTE]
+====
+Always use a real, monitored email address for organization notifications. Dummy addresses cause undelivered alerts.
 ====
 
 .Prerequisites
 
-* You have link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_api_guide/inde
-x#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 * You have organization administrator permissions.
 
 .Procedure
@@ -44,13 +48,12 @@ $ curl -X GET \
 {
 "name": "engineering",
 "email": "team-notifications@example.com",
-"contact_email": "team-notifications@example.com",
 "is_admin": true,
 ...
 }
 ----
 +
-When `contact_email` is not set, the response returns `null` and `email` returns an empty string.
+When no contact email is set, `email` returns an empty string. The GET response does not include a separate `contact_email` field.
 
 * To set the contact email when creating an organization, use the following `POST /api/v1/organization/` endpoint:
 +
@@ -62,6 +65,8 @@ $ curl -X POST \
 -d '{"name": "engineering", "contact_email": "team-alerts@example.com"}' \
 "https://<quay-server.example.com>/api/v1/organization/"
 ----
++
+You can also send `"email": "team-alerts@example.com"`. If both fields are present, `contact_email` takes priority.
 
 * To change the contact email for an existing organization, use the following `PUT /api/v1/organization/{orgname}` endpoint:
 +
@@ -85,7 +90,7 @@ $ curl -X PUT \
 "https://<quay-server.example.com>/api/v1/organization/engineering"
 ----
 
-* If you want multiple organizations to use the same `contact_email` address, use team distribution lists. These lists can send all alerts for multiple namespaces to a single shared inbox.
+* If you want multiple organizations to use the same contact email address, use a team distribution list:
 +
 [source,terminal]
 ----
@@ -101,5 +106,4 @@ $ curl -X PUT -H "Authorization: Bearer <token>" -H "Content-Type: application/j
 "https://<quay-server.example.com>/api/v1/organization/qa-team"
 ----
 +
-The command examples show that both `engineering` and `qa-team` receive notifications at `devops-team@example.com`.
-
+Both `engineering` and `qa-team` can use `devops-team@example.com` as their organization email.

--- a/modules/org-contact-email-api.adoc
+++ b/modules/org-contact-email-api.adoc
@@ -1,0 +1,105 @@
+// module included in the following assemblies:
+
+// * use_quay/master.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="org-contact-email-api-change"]
+= Managing organization contact email with the API
+
+[role="_abstract"]
+Use the `contact_email` field to configure where automated system alerts are sent for an organization. This field is decoupled from user account identities, allowing multiple organizations to share the same email address without authentication conflicts.
+
+The `contact_email` field has the following properties:
+
+* Receives automated notifications including quota warnings, security alerts, and build failures
+* Can be shared across multiple organizations (useful for team distribution lists)
+* An optional field so if not set, notifications default to organization owners
+* Does not enforce global uniqueness constraints
+
+[NOTE]
+====
+Before the `contact_email` field, organizations were forced to use unique dummy email addresses to avoid account collision errors. This resulted in undelivered notifications. Always use a real, monitored email address for the `contact_email` field.
+====
+
+.Prerequisites
+
+* You have link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_api_guide/inde
+x#creating-oauth-access-token[Created an OAuth access token].
+* You have organization administrator permissions.
+
+.Procedure
+
+* To retrieve the current contact email, use the following `GET /api/v1/organization/{orgname}` endpoint:
++
+[source,terminal]
+----
+$ curl -X GET \
+-H "Authorization: Bearer <bearer_token>" \
+"https://<quay-server.example.com>/api/v1/organization/engineering"
+----
++
+.Example response
+[source,json]
+----
+{
+"name": "engineering",
+"email": "team-notifications@example.com",
+"contact_email": "team-notifications@example.com",
+"is_admin": true,
+...
+}
+----
++
+When `contact_email` is not set, the response returns `null` and `email` returns an empty string.
+
+* To set the contact email when creating an organization, use the following `POST /api/v1/organization/` endpoint:
++
+[source,terminal]
+----
+$ curl -X POST \
+-H "Authorization: Bearer <bearer_token>" \
+-H "Content-Type: application/json" \
+-d '{"name": "engineering", "contact_email": "team-alerts@example.com"}' \
+"https://<quay-server.example.com>/api/v1/organization/"
+----
+
+* To change the contact email for an existing organization, use the following `PUT /api/v1/organization/{orgname}` endpoint:
++
+[source,terminal]
+----
+$ curl -X PUT \
+-H "Authorization: Bearer <bearer_token>" \
+-H "Content-Type: application/json" \
+-d '{"contact_email": "new-team-alerts@example.com"}' \
+"https://<quay-server.example.com>/api/v1/organization/engineering"
+----
+
+* To remove the contact email, set the `contact_email` field to `null`. Notifications then default to organization owners.
++
+[source,terminal]
+----
+$ curl -X PUT \
+-H "Authorization: Bearer <bearer_token>" \
+-H "Content-Type: application/json" \
+-d '{"contact_email": null}' \
+"https://<quay-server.example.com>/api/v1/organization/engineering"
+----
+
+* If you want multiple organizations to use the same `contact_email` address, use team distribution lists. These lists can send all alerts for multiple namespaces to a single shared inbox.
++
+[source,terminal]
+----
+$ curl -X PUT -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
+-d '{"contact_email": "devops-team@example.com"}' \
+"https://<quay-server.example.com>/api/v1/organization/engineering"
+----
++
+[source,terminal]
+----
+$ curl -X PUT -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
+-d '{"contact_email": "devops-team@example.com"}' \
+"https://<quay-server.example.com>/api/v1/organization/qa-team"
+----
++
+The command examples show that both `engineering` and `qa-team` receive notifications at `devops-team@example.com`.
+

--- a/modules/org-create.adoc
+++ b/modules/org-create.adoc
@@ -7,7 +7,8 @@
 [id="org-create"]
 = Creating an organization by using the UI
 
-Use the following procedure to create a new organization by using the UI. 
+[role="_abstract"]
+You can create a new organization by using the user interface (UI). 
 
 .Procedure
 
@@ -19,8 +20,13 @@ Use the following procedure to create a new organization by using the UI.
 
 . Enter an *Organization Name*, for example, `testorg`. 
 
-. Enter an *Organization Email*.
+. Optional: Enter a *Contact Email* for the organization. This email receives automated system alerts including quota warnings, security notifications, and build failures. If not specified, notifications default to the organization creator and owners.
++
+[NOTE]
+====
+Multiple organizations can share the same contact email address, such as a team distribution list.
+====
 
 . Click *Create*. 
-
-Now, your example organization should populate under the *Organizations* page. 
++
+Now, your example organization should populate under the *Organizations* page.

--- a/modules/org-create.adoc
+++ b/modules/org-create.adoc
@@ -20,11 +20,11 @@ You can create a new organization by using the user interface (UI).
 
 . Enter an *Organization Name*, for example, `testorg`. 
 
-. Optional: Enter a *Contact Email* for the organization. This email receives automated system alerts including quota warnings, security notifications, and build failures. If not specified, notifications default to the organization creator and owners.
+. Enter an *Organization Email* for the organization. This email receives automated system alerts including quota warnings, security notifications, and build failures.
 +
 [NOTE]
 ====
-Multiple organizations can share the same contact email address, such as a team distribution list.
+Multiple organizations can share the same organization email address, such as a team distribution list. By default, the address cannot match a user account email unless `FEATURE_ORG_SHARED_EMAIL` is enabled in your {productname} configuration.
 ====
 
 . Click *Create*. 

--- a/modules/organization-settings-v2-ui.adoc
+++ b/modules/organization-settings-v2-ui.adoc
@@ -28,11 +28,11 @@ Use the following procedure to alter your organization settings by using the v2 
 
 . Click the *Settings* tab. 
 
-. Optional. Enter the *Contact Email* for the organization in the *Email* field. This email receives automated system alerts including quota warnings, security notifications, and build failures.
+. Optional. Enter or update the organization *Email Address*. This email receives automated system alerts including quota warnings, security notifications, and build failures.
 +
 [NOTE]
 ====
-Multiple organizations can share the same contact email address. This is useful for teams managing multiple namespaces who want all alerts sent to a shared distribution list.
+Multiple organizations can share the same email address, such as a team distribution list. By default, the address cannot match a user account email unless `FEATURE_ORG_SHARED_EMAIL` is enabled in your {productname} configuration.
 ====
 
 . Optional. Set the allotted time for the *Time Machine* feature to one of the following:

--- a/modules/organization-settings-v2-ui.adoc
+++ b/modules/organization-settings-v2-ui.adoc
@@ -8,12 +8,13 @@
 [id="organization-settings-v2-ui"]
 = Organization settings
 
+[role="_abstract"]
 With 
 ifeval::["{context}" == "quay-io"]
-= {quayio},
+{quayio},
 endif::[]
 ifeval::["{context}" == "use-quay"]
-= {productname},
+{productname},
 endif::[]
 some basic organization settings can be adjusted by using the UI. This includes adjusting general settings, such as the e-mail address associated with the organization, and _time machine_ settings, which allows administrators to adjust when a tag is garbage collected after it is permanently deleted. 
 
@@ -27,7 +28,12 @@ Use the following procedure to alter your organization settings by using the v2 
 
 . Click the *Settings* tab. 
 
-. Optional. Enter the email address associated with the organization. 
+. Optional. Enter the *Contact Email* for the organization in the *Email* field. This email receives automated system alerts including quota warnings, security notifications, and build failures.
++
+[NOTE]
+====
+Multiple organizations can share the same contact email address. This is useful for teams managing multiple namespaces who want all alerts sent to a shared distribution list.
+====
 
 . Optional. Set the allotted time for the *Time Machine* feature to one of the following:
 +
@@ -37,4 +43,4 @@ Use the following procedure to alter your organization settings by using the v2 
 * *14 days*
 * *A month*
 
-. Click *Save*. 
+. Click *Save*.


### PR DESCRIPTION
## Summary
- Corrects organization contact-email API docs from [#1681](https://github.com/quay/quay-docs/pull/1681) to match Quay 3.18 behavior validated against `fc4a409d2d2f`
- GET returns `email` only (not a separate `contact_email` field); request bodies may still use `contact_email`
- Documents that org-to-org email sharing works by default; reusing a user account email requires `FEATURE_ORG_SHARED_EMAIL`
- Aligns UI procedure labels with the current Angular UI (`Organization Email` / `Email Address`)

## Test plan
- [x] Retest create/update/clear/share org email APIs on local Quay 3.18
- [x] Confirm GET response shape and user-email collision without `FEATURE_ORG_SHARED_EMAIL`
- [ ] Darragh review / merge into or replace [#1681](https://github.com/quay/quay-docs/pull/1681) as preferred


Made with [Cursor](https://cursor.com)