### PR TITLE
Adds 3.9.24 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -15,7 +15,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.9
-:productminv: v3.9.22
+:productminv: v3.9.24
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -31,8 +31,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.9
-:productmin: 3.9.22
-:productminv: v3.9.22
+:productmin: 3.9.24
+:productminv: v3.9.24
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_90.adoc
+++ b/modules/rn_3_90.adoc
@@ -5,6 +5,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+[id="rn-3-9024"]
+== RHSA-2026:40262 - {productname} 3.9.24 release
+
+Issued 2026-7-15
+
+{productname} release 3.9.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:40262[RHSA-2026:40262] advisory.
+
+
 [id="rn-3-9022"]
 == RHSA-2026:23361 - {productname} 3.9.22 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.9.24
- Source: https://github.com/quay/quay-konflux-configs/pull/233
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12388

## Skipped (not documented)
All 24 fixed issues are CVE-only. Advisory-only entry per 3.9 y-stream convention.

Skipped: PROJQUAY-12114, PROJQUAY-12082, PROJQUAY-12053, PROJQUAY-12042, PROJQUAY-12032, PROJQUAY-11994, PROJQUAY-11987, PROJQUAY-11973, PROJQUAY-11958, PROJQUAY-11918, PROJQUAY-11900, PROJQUAY-11880, PROJQUAY-11876, PROJQUAY-11865, PROJQUAY-11848, PROJQUAY-11819, PROJQUAY-11787, PROJQUAY-11783, PROJQUAY-11775, PROJQUAY-11754, PROJQUAY-11746, PROJQUAY-11740, PROJQUAY-11706, PROJQUAY-10894.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:40262, issued 2026-07-15)
- [ ] Attributes updated to 3.9.24
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.9


Made with [Cursor](https://cursor.com)