### PR TITLE
Adds 3.10.24 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.10
-:productminv: v3.10.23
+:productminv: v3.10.24
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -33,8 +33,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.10
-:productmin: 3.10.23
-:productminv: v3.10.23
+:productmin: 3.10.24
+:productminv: v3.10.24
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -4,6 +4,15 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+[id="rn-3-10-24"]
+== RHSA-2026:41031 - {productname} 3.10.24 release
+
+Issued 2026-07-16
+
+{productname} release 3.10.24 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:41031[RHSA-2026:41031] advisory.
+
+
+
 [id="rn-3-10-23"]
 == RHSA-2026:33683 - {productname} 3.10.23 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.10.24
- Source: https://github.com/quay/quay-konflux-configs/pull/238
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12389

## Skipped (not documented)
All 24 fixed issues are CVE-only. Advisory-only entry per 3.10 y-stream convention.

Skipped: PROJQUAY-12117, PROJQUAY-12050, PROJQUAY-12039, PROJQUAY-12029, PROJQUAY-11996, PROJQUAY-11986, PROJQUAY-11985, PROJQUAY-11967, PROJQUAY-11961, PROJQUAY-11919, PROJQUAY-11894, PROJQUAY-11882, PROJQUAY-11871, PROJQUAY-11866, PROJQUAY-11845, PROJQUAY-11812, PROJQUAY-11793, PROJQUAY-11772, PROJQUAY-11771, PROJQUAY-11761, PROJQUAY-11750, PROJQUAY-11742, PROJQUAY-11708, PROJQUAY-10888.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:41031, issued 2026-07-16)
- [ ] Attributes updated to 3.10.24
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.10


Made with [Cursor](https://cursor.com)