### PR TITLE
Adds 3.16.5 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.16
-:productminv: v3.16.4
+:productminv: v3.16.5
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productversion: 3
 :producty: 3.16
 :producty-n1: 3.15
-:productmin: 3.16.4
-:productminv: v3.16.4
+:productmin: 3.16.5
+:productminv: v3.16.5
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel9
 :clairimage: clair-rhel9

--- a/modules/rn-3-16-5.adoc
+++ b/modules/rn-3-16-5.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: REFERENCE
+[id="rn-3-16-5"]
+= RHSA-2026:41066 - {productname} 3.16.5 release
+
+Issued 2026-07-16
+
+[role="_abstract"]
+{productname} release 3.16.5 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:41066[RHSA-2026:41066] advisory.
+
+[id="bug-fixes-316-5"]
+== {productname} 3.16.5 bug fixes
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12209[*PROJQUAY-12209*]. Previously, after {productname} finished pulling all missing layers for a cached image, Clair was not triggered to rescan the image. Security scanning remained incomplete until an administrator manually reset the scan status.
++
+With this release, {productname} resets the scanning status when an image is successfully cached with all layers. As a result, Clair rescans the image automatically after layer retrieval completes.

--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -33,6 +33,7 @@ endif::downstream[]
 
 
 include::modules/rn_overview.adoc[leveloffset=+1]
+include::modules/rn-3-16-5.adoc[leveloffset=+2]
 include::modules/rn-3-16-4.adoc[leveloffset=+2]
 include::modules/rn-3-16-3.adoc[leveloffset=+2]
 include::modules/rn-3-16-2.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.16.5
- Source: https://github.com/quay/quay-konflux-configs/pull/236
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12390
- Documents PROJQUAY-12209 (Clair rescan after all layers cached)

## Skipped (not documented)
- CVE-only: PROJQUAY-12119, PROJQUAY-12081, PROJQUAY-12068, PROJQUAY-12049, PROJQUAY-12044, PROJQUAY-12034, PROJQUAY-11995, PROJQUAY-11990, PROJQUAY-11969, PROJQUAY-11964, PROJQUAY-11917, PROJQUAY-11898, PROJQUAY-11885, PROJQUAY-11874, PROJQUAY-11859, PROJQUAY-11849, PROJQUAY-11815, PROJQUAY-11788, PROJQUAY-11779, PROJQUAY-11777, PROJQUAY-11767, PROJQUAY-11755, PROJQUAY-11751, PROJQUAY-11739, PROJQUAY-11733, PROJQUAY-11717, PROJQUAY-11709, PROJQUAY-11695, PROJQUAY-11676, PROJQUAY-11662, PROJQUAY-11597, PROJQUAY-11572, PROJQUAY-11492, PROJQUAY-10893
- Red Hat Employee security: PROJQUAY-11655

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:41066, issued 2026-07-16)
- [ ] Attributes updated to 3.16.5; module included in release_notes/master.adoc
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.16


Made with [Cursor](https://cursor.com)