### PR TITLE
Adds 3.12.20 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.12
-:productminv: v3.12.17
+:productminv: v3.12.20
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.12
-:productmin: 3.12.17
-:productminv: v3.12.17
+:productmin: 3.12.20
+:productminv: v3.12.20
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.12
-:productminv: v3.12.18
+:productminv: v3.12.20
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.12
-:productmin: 3.12.18
-:productminv: v3.12.18
+:productmin: 3.12.20
+:productminv: v3.12.20
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_12.adoc
+++ b/modules/rn_3_12.adoc
@@ -4,6 +4,21 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+[id="rn-3-12-20"]
+== RHSA-2026:43052 - {productname} 3.12.20 release
+
+Issued 2026-07-21
+
+{productname} release 3.12.20 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:43052[RHSA-2026:43052] advisory.
+
+[id="bug-fixes-312-20"]
+=== {productname} 3.12.20 bug fixes
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11338[*PROJQUAY-11338*]. Previously, a malformed struct tag on `DistributedStorageArgs.Signature` caused storage configuration to serialize as `Signature` instead of `signature_version`. Operator-managed object storage deployments could fail during upgrade with `TypeError: RadosGWStorage.__init__() got an unexpected keyword argument 'Signature'`.
++
+With this release, the signature version field serializes correctly and omits empty values. As a result, Operator-managed storage configurations load without upgrade failures.
+
+
 [id="rn-3-12-18"]
 == RHSA-2026:22629 - {productname} 3.12.18 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.12.20
- Source: https://github.com/quay/quay-konflux-configs/pull/239
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12391
- Documents PROJQUAY-11338 (malformed Signature struct tag / storage config)

## Skipped (not documented)
CVE-only: PROJQUAY-12118, PROJQUAY-12052, PROJQUAY-12040, PROJQUAY-12030, PROJQUAY-11993, PROJQUAY-11968, PROJQUAY-11962, PROJQUAY-11916, PROJQUAY-11895, PROJQUAY-11879, PROJQUAY-11878, PROJQUAY-11863, PROJQUAY-11844, PROJQUAY-11816, PROJQUAY-11789, PROJQUAY-11780, PROJQUAY-11773, PROJQUAY-11760, PROJQUAY-11748, PROJQUAY-11741, PROJQUAY-11707, PROJQUAY-10889.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:43052, issued 2026-07-21)
- [ ] Attributes updated to 3.12.20
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.12


Made with [Cursor](https://cursor.com)