### PR TITLE
Adds 3.15.6 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.15
-:productminv: v3.15.4
+:productminv: v3.15.6
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productversion: 3
 :producty: 3.15
 :producty-n1: 3.14
-:productmin: 3.15.4
-:productminv: v3.15.4
+:productmin: 3.15.6
+:productminv: v3.15.6
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn-3-15-6.adoc
+++ b/modules/rn-3-15-6.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: REFERENCE
+[id="rn-3-15-6"]
+= RHSA-2026:42796 - {productname} 3.15.6 release
+
+Issued 2026-07-21
+
+[role="_abstract"]
+{productname} release 3.15.6 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:42796[RHSA-2026:42796] advisory.
+
+[id="bug-fixes-315-6"]
+== {productname} 3.15.6 bug fixes
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9369[*PROJQUAY-9369*]. Previously, after {productname} finished pulling all missing layers for a cached image, Clair was not triggered to rescan the image. Security scanning remained incomplete until an administrator manually reset the scan status.
++
+With this release, {productname} resets the scanning status when an image is successfully cached with all layers. As a result, Clair rescans the image automatically after layer retrieval completes.

--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -33,6 +33,7 @@ endif::downstream[]
 
 
 include::modules/rn_overview.adoc[leveloffset=+1]
+include::modules/rn-3-15-6.adoc[leveloffset=+2]
 include::modules/rn-3-15-4.adoc[leveloffset=+2]
 include::modules/rn-3-15-3.adoc[leveloffset=+2]
 include::modules/rn-3-15-2.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.15.6
- Source: https://github.com/quay/quay-konflux-configs/pull/234
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12392
- Documents PROJQUAY-9369 (Clair rescan after all layers cached)

## Skipped (not documented)
CVE-only: PROJQUAY-12055, PROJQUAY-12041, PROJQUAY-12031, PROJQUAY-11992, PROJQUAY-11989, PROJQUAY-11972, PROJQUAY-11959, PROJQUAY-11920, PROJQUAY-11896, PROJQUAY-11881, PROJQUAY-11873, PROJQUAY-11861, PROJQUAY-11847, PROJQUAY-11817, PROJQUAY-11790, PROJQUAY-11784, PROJQUAY-11774, PROJQUAY-11770, PROJQUAY-11758, PROJQUAY-11747, PROJQUAY-11743, PROJQUAY-11734, PROJQUAY-11719, PROJQUAY-11713, PROJQUAY-11705, PROJQUAY-11675, PROJQUAY-11596, PROJQUAY-10892.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:42796, issued 2026-07-21)
- [ ] Attributes updated to 3.15.6; module included in release_notes/master.adoc
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.15


Made with [Cursor](https://cursor.com)