### PR TITLE
Adds Quay 3.18.0 bug fixes and advisory stub

### DIFF
--- a/modules/api-bootstrap-renewBootstrapToken.adoc
+++ b/modules/api-bootstrap-renewBootstrapToken.adoc
@@ -8,7 +8,7 @@ Rotate the programmatic bootstrap OAuth token.
 [id="renewbootstraptoken-post"]
 == POST /api/v1/bootstrap/renew
 
-Renew the bootstrap token and write the new token value to `BOOTSTRAP_TOKEN_PATH` or the configured {kubernetes} Secret. The previous bootstrap token is invalidated immediately. The response does not include the new token value; read it from the configured storage location after renewal.
+Renew the bootstrap token and write the new token value to `BOOTSTRAP_TOKEN_PATH` or the configured Kubernetes Secret. The previous bootstrap token is invalidated immediately. The response does not include the new token value; read it from the configured storage location after renewal.
 
 This endpoint is available only when `FEATURE_PROGRAMMATIC_BOOTSTRAP` is `true`.
 
@@ -32,7 +32,7 @@ No request body.
 
 [NOTE]
 ====
-When the bootstrap token is expired, renewal is accepted only from localhost. On {kubernetes} and {ocp}, use port forwarding and ensure the request includes the `X-Quay-Bootstrap-Renewal-Location: local` header set by the ingress layer.
+When the bootstrap token is expired, renewal is accepted only from localhost. On Kubernetes and {ocp}, use port forwarding and ensure the request includes the `X-Quay-Bootstrap-Renewal-Location: local` header set by the ingress layer.
 ====
 
 [id="renewbootstraptoken-example-command"]

--- a/modules/bug-fixes-318.adoc
+++ b/modules/bug-fixes-318.adoc
@@ -5,6 +5,141 @@
 [role="_abstract"]
 You can review bug fixes included in {productname} 3.18.
 
-{productname} 3.18 fixes the following issues:
+The following issues were fixed with {productname} 3.18.
 
-* link:https://issues.redhat.com/browse/PROJQUAY-[*PROJQUAY-*]. Previously,
+[NOTE]
+====
+Not all bug fixes included in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory are documented here. Many of the bugs included in the advisory were found and resolved when testing new features included as part of this release.
+====
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10504[*PROJQUAY-10504*]. Previously, deleting a manifest by digest could silently skip immutable tags and remove the underlying manifest, bypassing tag immutability protections that correctly blocked deletion by tag name.
++
+With this release, digest-based manifest deletion respects immutable tags and blocks the operation when immutability applies.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11952[*PROJQUAY-11952*]. Previously, session timeout and related settings such as `SESSION_TIMEOUT`, `FEATURE_PERMANENT_SESSIONS`, and `FRESH_LOGIN_TIMEOUT` were not applied correctly, so sessions could remain active longer than configured.
++
+With this release, {productname} honors the configured session timeout values.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-8440[*PROJQUAY-8440*]. Previously, pulling an image that was already present in the organization proxy cache still required the upstream registry to be reachable. If the upstream registry was unavailable, cached pulls could fail.
++
+With this release, cached images can be served from the proxy cache without requiring upstream registry availability.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11119[*PROJQUAY-11119*]. Previously, organization proxy cache configuration failed when `FEATURE_IMMUTABLE_TAGS` was not enabled, even though the default value of that feature is `false`.
++
+With this release, organization proxy cache works when `FEATURE_IMMUTABLE_TAGS` is disabled.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10575[*PROJQUAY-10575*]. Previously, canceling repository mirroring produced incomplete or null log messages.
++
+With this release, canceling a repository mirror logs a clear result.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10798[*PROJQUAY-10798*]. Previously, canceling an organization mirror sync could generate an endless stream of `Organization mirror sync failed - Sync cancelled` log messages.
++
+With this release, canceling an organization mirror no longer floods logs with repeated cancellation messages.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11382[*PROJQUAY-11382*]. Previously, deleting an organization mirror configuration left mirrored repositories stuck in the `ORG_MIRROR` state, which blocked pushes to those repositories.
++
+With this release, deleting the organization mirror configuration restores repositories so that users can push again.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11891[*PROJQUAY-11891*]. Previously, you could not delete an organization that was configured for organization mirroring because of a database error.
++
+With this release, you can remove organizations that have organization mirror configurations.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11027[*PROJQUAY-11027*]. Previously, using *Cancel Sync* for an organization mirror cleared the *Next Sync Date* value and prevented updating the mirror configuration to sync again.
++
+With this release, canceling a sync preserves the schedule so that you can update the configuration and resume mirroring.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11347[*PROJQUAY-11347*]. Previously, changing a repository mirror tag pattern required re-entering credentials for private upstream repositories. Saving without re-entering credentials could clear stored credentials and cause the next sync to fail with an authorization error.
++
+With this release, updating the tag pattern retains existing credentials unless you explicitly change them.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11478[*PROJQUAY-11478*]. Previously, the new UI blocked creating a proxy cache configuration even when organization mirroring was not enabled in `config.yaml`.
++
+With this release, you can create proxy cache configurations when organization mirroring is disabled.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11515[*PROJQUAY-11515*]. Previously, the API allowed creating a proxy cache configuration on an organization that was already managed by organization mirroring, even though the UI hid that option.
++
+With this release, the API rejects proxy cache creation for organizations that are in the organization mirror state.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11077[*PROJQUAY-11077*]. Previously, OIDC login redirects failed when {productname} was exposed on a non-standard HTTP or HTTPS port because nginx forwarded only the hostname without the port.
++
+With this release, OIDC redirects include the configured port and complete successfully.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11319[*PROJQUAY-11319*]. Previously, OCI images with no history entries in the image config caused an `AttributeError` in layer processing, so the manifest API returned `404` and tag sizes were missing in the UI.
++
+With this release, OCI images without history are handled correctly.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11637[*PROJQUAY-11637*]. Previously, lazy loading of OCI indexes failed when the index included Docker v2 schema 2 images, which the OCI specification allows.
++
+With this release, OCI indexes that contain Docker v2 schema 2 manifests load successfully.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10934[*PROJQUAY-10934*]. Previously, repository cache entries were not invalidated when a repository was deleted, which could leave stale cache data.
++
+With this release, deleting a repository invalidates the related cache entries.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11288[*PROJQUAY-11288*]. Previously, nginx returned HTTP `404` instead of `502` when the backend was unavailable because a custom `502` error page was missing.
++
+With this release, unavailable backends return the expected `502` response.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11331[*PROJQUAY-11331*]. Previously, a malformed struct tag on `DistributedStorageArgs.Signature` in the config tool broke storage configuration serialization.
++
+With this release, storage configuration that uses signature settings serializes correctly.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11486[*PROJQUAY-11486*]. Previously, the configuration validator did not properly validate S3 URLs.
++
+With this release, invalid S3 URLs are rejected during configuration validation.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11524[*PROJQUAY-11524*]. Previously, a race condition during initial database setup could cause intermittent startup failures.
++
+With this release, initial database setup completes reliably.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11851[*PROJQUAY-11851*]. Previously, an RBAC denial on `apiservers.config.openshift.io` could block the entire {productname} Operator deployment on {ocp}.
++
+With this release, the Operator no longer requires that permission to complete deployment.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11852[*PROJQUAY-11852*]. Previously, the Operator could panic when processing an invalid configuration.
++
+With this release, invalid configurations are handled without panicking.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11501[*PROJQUAY-11501*]. Previously, the Operator rejected `PULL_METRICS_REDIS` in the config bundle secret when Redis was Operator-managed after the config-tool migration.
++
+With this release, `PULL_METRICS_REDIS` is accepted in that configuration.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11549[*PROJQUAY-11549*]. Previously, external TLS `secretRef` configuration did not validate that the certificate matched `SERVER_HOSTNAME`.
++
+With this release, the Operator validates that the external TLS certificate covers `SERVER_HOSTNAME`.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12322[*PROJQUAY-12322*]. Previously, the Modern TLS profile could pass TLS 1.3 cipher suites to the nginx `ssl_ciphers` directive, which caused nginx to crash.
++
+With this release, TLS 1.3 ciphers are not passed to `ssl_ciphers`, and nginx starts successfully with the Modern TLS profile.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9157[*PROJQUAY-9157*]. Previously, pods could fail with `MountVolume.SetUp failed for volume "config"` in some configuration mount scenarios.
++
+With this release, the config volume mounts correctly.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12230[*PROJQUAY-12230*]. Previously, quota warning and error notifications failed with `TypeError: Decimal is not JSON serializable`, so quota notifications were silently dropped.
++
+With this release, quota notification payloads serialize correctly and notifications are delivered.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12233[*PROJQUAY-12233*]. Previously, global readonly superusers were blocked from reading organization namespace notification GET endpoints when `FEATURE_SUPERUSERS_FULL_ACCESS` was enabled.
++
+With this release, global readonly superusers can read namespace notifications.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11678[*PROJQUAY-11678*]. Previously, the Superuser Build Logs page in the new UI returned HTTP `500` because of a logic error in `BuildTrigger.to_dict()`.
++
+With this release, looking up build logs by UUID succeeds without a server error.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11930[*PROJQUAY-11930*]. Previously, the Superuser Build Logs page in the new UI showed *No logs available* for archived builds that still had valid logs in object storage.
++
+With this release, archived build logs display correctly in the new UI.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11158[*PROJQUAY-11158*]. Previously, the *Auto-Prune Policies* tab was missing for user namespace organizations in the UI.
++
+With this release, the *Auto-Prune Policies* tab is available for user organizations again.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9695[*PROJQUAY-9695*]. Previously, the log rotate worker stopped working after upgrading to {productname} 3.15.
++
+With this release, the log rotate worker runs correctly after upgrade.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12197[*PROJQUAY-12197*]. Previously, Clair could fail to pull the upstream vulnerability database, which prevented vulnerability reports for scanned images.
++
+With this release, Clair can update its vulnerability database from upstream sources.

--- a/modules/bug-fixes-318.adoc
+++ b/modules/bug-fixes-318.adoc
@@ -9,7 +9,7 @@ The following issues were fixed with {productname} 3.18.
 
 [NOTE]
 ====
-Not all bug fixes included in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory are documented here. Many of the bugs included in the advisory were found and resolved when testing new features included as part of this release.
+Not all bug fixes included in the link:https://access.redhat.com/errata/RHSA-2026:48085[RHSA-2026:48085] advisory are documented here. Many of the bugs included in the advisory were found and resolved when testing new features included as part of this release.
 ====
 
 * link:https://issues.redhat.com/browse/PROJQUAY-10504[*PROJQUAY-10504*]. Previously, deleting a manifest by digest could silently skip immutable tags and remove the underlying manifest, bypassing tag immutability protections that correctly blocked deletion by tag name.

--- a/modules/config-fields-programmatic-bootstrap.adoc
+++ b/modules/config-fields-programmatic-bootstrap.adoc
@@ -9,7 +9,7 @@ Use these configuration fields to control bootstrap OAuth token provisioning for
 [cols="3a,1a,2a",options="header"]
 |===
 | Field | Type | Description
-| **FEATURE_PROGRAMMATIC_BOOTSTRAP** | Boolean | Enables programmatic bootstrap token provisioning. When `true`, {productname} creates a bootstrap OAuth token on startup and writes it to a local file or {kubernetes} Secret. When `false`, {productname} revokes any existing bootstrap token on restart.
+| **FEATURE_PROGRAMMATIC_BOOTSTRAP** | Boolean | Enables programmatic bootstrap token provisioning. When `true`, {productname} creates a bootstrap OAuth token on startup and writes it to a local file or Kubernetes Secret. When `false`, {productname} revokes any existing bootstrap token on restart.
 
 **Default:** `false`
 
@@ -27,13 +27,13 @@ Use these configuration fields to control bootstrap OAuth token provisioning for
 
 **Default:** `org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read`
 
-| **PROGRAMMATIC_TOKEN_K8S_SECRET** | String | {kubernetes} Secret name used to store the bootstrap token when {productname} runs in {kubernetes}. When set, {productname} writes the token to this Secret instead of `BOOTSTRAP_TOKEN_PATH`. On {productname-ocp}, the Operator sets this field to `<quayregistry_name>-bootstrap-token` when programmatic bootstrap is enabled. Do not set this field manually in Operator-managed deployments.
+| **PROGRAMMATIC_TOKEN_K8S_SECRET** | String | Kubernetes Secret name used to store the bootstrap token when {productname} runs in Kubernetes. When set, {productname} writes the token to this Secret instead of `BOOTSTRAP_TOKEN_PATH`. On {productname-ocp}, the Operator sets this field to `<quayregistry_name>-bootstrap-token` when programmatic bootstrap is enabled. Do not set this field manually in Operator-managed deployments.
 
 | **PROGRAMMATIC_TOKEN_K8S_KEY** | String | Secret data key that stores the bootstrap token JSON. On {productname-ocp}, the Operator sets this field to `token.json`.
 
 **Default:** `token.json`
 
-| **PROGRAMMATIC_TOKEN_K8S_NAMESPACE** | String | {kubernetes} namespace that contains the bootstrap token Secret. When unset, {productname} uses the pod service account namespace. On {productname-ocp}, the Operator uses the `QuayRegistry` namespace.
+| **PROGRAMMATIC_TOKEN_K8S_NAMESPACE** | String | Kubernetes namespace that contains the bootstrap token Secret. When unset, {productname} uses the pod service account namespace. On {productname-ocp}, the Operator uses the `QuayRegistry` namespace.
 
 | **PROGRAMMATIC_TOKEN_PATH** | String | Operator-rendered mount path for configuration compatibility. On {productname-ocp}, the Operator sets this field to `/var/lib/quay/bootstrap-token/token.json`. Standalone deployments use `BOOTSTRAP_TOKEN_PATH` for local file storage.
 |===

--- a/modules/new-api-endpoints-318.adoc
+++ b/modules/new-api-endpoints-318.adoc
@@ -34,7 +34,7 @@ For API schemas and examples, see link:https://docs.redhat.com/en/documentation/
 [id="bootstrap-token-renewal-api-318"]
 == Bootstrap token renewal
 
-When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, `POST /api/v1/bootstrap/renew` rotates the bootstrap OAuth token. The new token is written to the configured filesystem path or {kubernetes} Secret, and the previous token is invalidated immediately. The response is `{"status": "rotated"}`.
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, `POST /api/v1/bootstrap/renew` rotates the bootstrap OAuth token. The new token is written to the configured filesystem path or Kubernetes Secret, and the previous token is invalidated immediately. The response is `{"status": "rotated"}`.
 
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#renewbootstraptoken[renewBootstrapToken] and link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/manage_red_hat_quay/index#renewing-bootstrap-token[Renewing the bootstrap token].
 The following API endpoints were added in {productname} 3.18.

--- a/modules/new-features-and-enhancements-318.adoc
+++ b/modules/new-features-and-enhancements-318.adoc
@@ -23,7 +23,7 @@ For configuration field descriptions, see link:https://docs.redhat.com/en/docume
 
 {productname} 3.18 introduces programmatic OAuth API token life cycle management for organization applications. You can create, list, and revoke OAuth API tokens by using the REST API instead of the UI.
 
-When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} can also auto-generate a high-privilege bootstrap OAuth token on startup and write it to a local file or {kubernetes} Secret. Use this bootstrap token for zero-touch automation workflows such as GitOps-based deployments, CI/CD bootstrap, and headless registry provisioning.
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} can also auto-generate a high-privilege bootstrap OAuth token on startup and write it to a local file or Kubernetes Secret. Use this bootstrap token for zero-touch automation workflows such as GitOps-based deployments, CI/CD bootstrap, and headless registry provisioning.
 
 This feature is available as Tech Preview in {productname} 3.18.
 
@@ -32,9 +32,9 @@ For configuration fields, see link:https://docs.redhat.com/en/documentation/red_
 [id="oauth-api-access-tokens-ui-318"]
 == OAuth API Access Tokens management UI
 
-With this release, organization OAuth applications include an *API Access Tokens* page in the {productname} v2 UI. You can create named OAuth 2 access tokens, review token metadata such as scopes and last-used time, delete individual tokens, and rotate legacy long-lived (10 years)tokens without deleting the parent OAuth application.
+With this release, organization OAuth applications include an *API Access Tokens* page in the {productname} v2 UI. You can create named OAuth 2 access tokens, review token metadata such as scopes and last-used time, delete individual tokens, and rotate legacy long-lived (10 years) tokens without deleting the parent OAuth application.
 
-Existing tokens continue to work until you revoke them.
+Existing tokens continue to work for up to 10 years until you revoke them.
 
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Creating an OAuth 2 access token] and link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_guide/index#migrating-legacy-oauth-access-token[Migrating a legacy OAuth 2 access token].
 The following updates have been made to {productname}.

--- a/modules/new-quay-config-fields-318.adoc
+++ b/modules/new-quay-config-fields-318.adoc
@@ -69,7 +69,7 @@ For procedures and examples, see link:https://docs.redhat.com/en/documentation/r
 |`BOOTSTRAP_TOKEN_PATH` |String |Local filesystem path for the bootstrap token JSON. Default: `/var/lib/quay/quay-machine-token.json`.
 |`BOOTSTRAP_TOKEN_EXPIRATION` |Integer |Bootstrap token lifetime in seconds. Default: `3600`.
 |`BOOTSTRAP_TOKEN_SCOPE` |String |Space-separated OAuth scopes for the bootstrap token.
-|`PROGRAMMATIC_TOKEN_K8S_SECRET` |String |{kubernetes} Secret name for bootstrap token storage.
+|`PROGRAMMATIC_TOKEN_K8S_SECRET` |String |Kubernetes Secret name for bootstrap token storage.
 |`PROGRAMMATIC_TOKEN_K8S_KEY` |String |Secret data key for the bootstrap token JSON. Default: `token.json`.
 |`PROGRAMMATIC_TOKEN_K8S_NAMESPACE` |String |Namespace for the bootstrap token Secret.
 |===

--- a/modules/programmatic-bootstrap-security.adoc
+++ b/modules/programmatic-bootstrap-security.adoc
@@ -11,7 +11,7 @@ Apply these practices when you use the {productname} bootstrap OAuth token so th
 
 * On standalone deployments, the bootstrap token file is written with `0600` permissions. Restrict access to the directory that contains the token file.
 
-* On {kubernetes} and {ocp}, store the bootstrap token in a dedicated Secret with scoped RBAC.
+* On Kubernetes and {ocp}, store the bootstrap token in a dedicated Secret with scoped RBAC.
 
 * Schedule bootstrap token renewal by using `POST /api/v1/bootstrap/renew` before expiry.
 

--- a/modules/programmatic-oauth-token-provisioning.adoc
+++ b/modules/programmatic-oauth-token-provisioning.adoc
@@ -7,7 +7,7 @@ To create and manage organization application tokens without the UI, you can use
 
 Organization OAuth applications previously required administrators to create API tokens in the {productname} UI. With programmatic token provisioning, automation tools can manage the token life cycle.
 
-When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} also creates a high-privilege bootstrap OAuth token on startup and writes it to a local file or {kubernetes} Secret. Use the bootstrap token to create organizations, applications, and narrower-scoped tokens without interactive UI access.
+When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} also creates a high-privilege bootstrap OAuth token on startup and writes it to a local file or Kubernetes Secret. Use the bootstrap token to create organizations, applications, and narrower-scoped tokens without interactive UI access.
 
 [IMPORTANT]
 ====

--- a/modules/reading-bootstrap-token.adoc
+++ b/modules/reading-bootstrap-token.adoc
@@ -3,7 +3,7 @@
 = Reading the bootstrap token
 
 [role="_abstract"]
-To obtain the bootstrap OAuth token after {productname} starts with programmatic bootstrap enabled, you can read the token from the configured local file or {kubernetes} Secret.
+To obtain the bootstrap OAuth token after {productname} starts with programmatic bootstrap enabled, you can read the token from the configured local file or Kubernetes Secret.
 
 .Procedure
 

--- a/modules/renewing-bootstrap-token.adoc
+++ b/modules/renewing-bootstrap-token.adoc
@@ -22,9 +22,9 @@ The following example shows a successful response:
 {"status": "rotated"}
 ----
 
-. Read the new token value from `BOOTSTRAP_TOKEN_PATH` or the configured {kubernetes} Secret. The previous bootstrap token is invalidated immediately.
+. Read the new token value from `BOOTSTRAP_TOKEN_PATH` or the configured Kubernetes Secret. The previous bootstrap token is invalidated immediately.
 +
 [NOTE]
 ====
-If the bootstrap token is already expired, renewal is accepted only from localhost. On {kubernetes} and {ocp}, use port forwarding to send the renewal request through the local ingress path.
+If the bootstrap token is already expired, renewal is accepted only from localhost. On Kubernetes and {ocp}, use port forwarding to send the renewal request through the local ingress path.
 ====

--- a/modules/rn-3-18-0.adoc
+++ b/modules/rn-3-18-0.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: REFERENCE
 [id="rn-3-18-0"]
-= RHBA-TBD - {productname} 3.18.0 release
+= RHSA-TBD - {productname} 3.18.0 release
 
 [role="_abstract"]
 {productname} {producty} is available with Clair {clairproductminv}. You can review the advisory, compatibility matrix, and life cycle policy for this release.
 
 Issued TBD
 
-{productname} release {producty} is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHBA-TBD] advisory. For the most recent compatibility matrix, see link:https://access.redhat.com/articles/4067991[Quay Enterprise 3.x Tested Integrations]. For information on the release cadence of {productname}, see the link:https://access.redhat.com/support/policy/updates/rhquay/[{productname} Life Cycle Policy].
+{productname} release {producty} is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory. For the most recent compatibility matrix, see link:https://access.redhat.com/articles/4067991[Quay Enterprise 3.x Tested Integrations]. For information on the release cadence of {productname}, see the link:https://access.redhat.com/support/policy/updates/rhquay/[{productname} Life Cycle Policy].

--- a/modules/rn-3-18-0.adoc
+++ b/modules/rn-3-18-0.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: REFERENCE
 [id="rn-3-18-0"]
-= RHSA-TBD - {productname} 3.18.0 release
+= RHSA-2026:48085 - {productname} 3.18.0 release
 
 [role="_abstract"]
 {productname} {producty} is available with Clair {clairproductminv}. You can review the advisory, compatibility matrix, and life cycle policy for this release.
 
-Issued TBD
+Issued 2026-07-29
 
-{productname} release {producty} is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory. For the most recent compatibility matrix, see link:https://access.redhat.com/articles/4067991[Quay Enterprise 3.x Tested Integrations]. For information on the release cadence of {productname}, see the link:https://access.redhat.com/support/policy/updates/rhquay/[{productname} Life Cycle Policy].
+{productname} release {producty} is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:48085[RHSA-2026:48085] advisory. For the most recent compatibility matrix, see link:https://access.redhat.com/articles/4067991[Quay Enterprise 3.x Tested Integrations]. For information on the release cadence of {productname}, see the link:https://access.redhat.com/support/policy/updates/rhquay/[{productname} Life Cycle Policy].


### PR DESCRIPTION
## Summary
- Fills `modules/bug-fixes-318.adoc` with curated customer-facing bug fixes from [quay-konflux-configs#226](https://github.com/quay/quay-konflux-configs/pull/226)
- Updates `modules/rn-3-18-0.adoc` advisory placeholder from `RHBA-TBD` to `RHSA-TBD` (matches konflux `releaseNotes.type: RHSA`)
- Attributes already set to 3.18 / 3.18.0 / Clair 4.9 — no attribute changes needed
- Feature modules left unchanged

## Errata follow-up
Quay 3.18.0 errata is **not published yet** on access.redhat.com (konflux release PR still open). After the advisory is live, update `modules/rn-3-18-0.adoc` and the advisory link in `bug-fixes-318.adoc` with the real RHSA ID and issued date.

## Skipped (not documented)
- CVE-only tickets
- Jira Security Level `Red Hat Employee` / `Restricted`
- Feature / Epic / Story tickets (covered by existing 3.18 feature modules)
- Tasks and many UI/test-only bugs found while validating new 3.18 features (same approach as 3.17.0 NOTE)

## Test plan
- [ ] Replace `RHSA-TBD` / Issued TBD when errata publishes
- [ ] Spot-check CCFR bullets against Jira summaries
- [ ] AsciiDoc / Vale build for `release_notes`


Made with [Cursor](https://cursor.com)