### PR TITLE
Follow up on quota notification docs (#1685)

### DIFF
--- a/modules/api-namespacenotification-createUserNotification.adoc
+++ b/modules/api-namespacenotification-createUserNotification.adoc
@@ -28,7 +28,7 @@ _required_|The notification delivery method. Options include `email`, `slack`, `
 `quay_notification`, `flowdock`, and `hipchat`.|string
 |**config** +
 _required_|JSON configuration for the notification method. Configuration varies by method
-type.|object
+type. For the `email` method on a user namespace, providing an empty object (`"config": {}`) is valid because recipient routing is handled server-side and notifications are sent to the user account email address.|object
 |**eventConfig** +
 _required_|JSON configuration for filtering which events trigger the notification.|object
 |**title** +

--- a/modules/api-namespacenotification-testOrgNotification.adoc
+++ b/modules/api-namespacenotification-testOrgNotification.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: REFERENCE
 
-= testUserNamespaceNotification
+= testOrgNotification
 
 
 [discrete]
-== POST /api/v1/user/namespacenotifications/{uuid}/test
+== POST /api/v1/organization/{orgname}/notifications/{uuid}/test
 
 
 
@@ -17,6 +17,8 @@
 [options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
+|path|**orgname** +
+_required_|The name of the organization|string
 |path|**uuid** +
 _required_|The uuid of the notification|string
 |===
@@ -42,7 +44,7 @@ _required_|The uuid of the notification|string
 ----
 $ curl -X POST \
 -H "Authorization: Bearer <bearer_token>" \
-https://<quay-server.example.com>/api/v1/user/namespacenotifications/<uuid>/test
+https://<quay-server.example.com>/api/v1/organization/<orgname>/notifications/<uuid>/test
 ----
 
 [discrete]
@@ -52,3 +54,8 @@ https://<quay-server.example.com>/api/v1/user/namespacenotifications/<uuid>/test
 ----
 {}
 ----
+
+[NOTE]
+====
+For *email* notifications, if an organization contact email is set, the test notification is routed to that address. Otherwise, email notifications default to all organization administrators. For other methods such as Slack or webhook, routing follows the notification `config`.
+====

--- a/modules/api-namespacenotification-testUserNamespaceNotification.adoc
+++ b/modules/api-namespacenotification-testUserNamespaceNotification.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: REFERENCE
 
-= getOrgNotification
+= testUserNamespaceNotification
 
 
 [discrete]
-== GET /api/v1/organization/{orgname}/notifications/{uuid} 
+== POST /api/v1/user/namespacenotifications/{uuid}/test
 
 
 
-**Authorizations: **oauth2_implicit (**org:admin** or global read-only **superuser**)
+**Authorizations: **oauth2_implicit (**user:admin**)
 
 
 [discrete]
@@ -17,10 +17,8 @@
 [options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
-|path|**orgname** +
-_required_|The name of the organization|string
 |path|**uuid** +
-_required_|The UUID of the notification|string
+_required_|The uuid of the notification|string
 |===
 
 
@@ -42,10 +40,9 @@ _required_|The UUID of the notification|string
 
 [source,terminal]
 ----
-$ curl -X GET \
+$ curl -X POST \
 -H "Authorization: Bearer <bearer_token>" \
--H "Accept: application/json" \
-https://<quay-server.example.com>/api/v1/organization/<orgname>/notifications/<uuid>
+https://<quay-server.example.com>/api/v1/user/namespacenotifications/<uuid>/test
 ----
 
 [discrete]
@@ -53,17 +50,10 @@ https://<quay-server.example.com>/api/v1/organization/<orgname>/notifications/<u
 
 [source,json]
 ----
-{
-"notifications": [
-    {
-    "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "title": "Quota Warning Alert",
-    "event": "quota_warning",
-    "method": "email",
-    "config": {},
-    "event_config": {},
-    "number_of_failures": 0
-    }
-]
-}
+{}
 ----
+
+[NOTE]
+====
+For *email* notifications, the test notification is routed to the user account email address. For other methods such as Slack or webhook, routing follows the notification `config`.
+====

--- a/modules/config-fields-quota-management.adoc
+++ b/modules/config-fields-quota-management.adoc
@@ -25,7 +25,7 @@ The following configuration fields enable and customize quota management functio
 
 **Default:** `86400`
 
-| **QUOTA_NOTIFICATION_WORKER_POLL_PERIOD** | Integer | Runs every 5 minutes to catch threshold crossings that happened between pushes. That is, when quota limits are lowered.
+| **QUOTA_NOTIFICATION_WORKER_POLL_PERIOD** | Integer | How often, in seconds, the quota notification background worker polls for threshold crossings that occur between image pushes—for example, when an administrator lowers a quota limit. Default: `300` (5 minutes).
 
 **Default:** `300`
 
@@ -60,7 +60,7 @@ DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: "100gb"
 QUOTA_BACKFILL: true
 QUOTA_TOTAL_DELAY_SECONDS: 3600
 QUOTA_NOTIFICATION_COOLDOWN_SECONDS: 86400
-QUOTA_NOTIFICATION_WORKER_POLL_PERIOD: 300s
+QUOTA_NOTIFICATION_WORKER_POLL_PERIOD: 300
 PERMANENTLY_DELETE_TAGS: true
 RESET_CHILD_MANIFEST_EXPIRATION: true
 # ...

--- a/modules/configuring-email-routing-contact-email.adoc
+++ b/modules/configuring-email-routing-contact-email.adoc
@@ -83,3 +83,8 @@ https://<quay-server.example.com>/api/v1/organization/<orgname>/notifications/<u
 ----
 {}
 ----
++
+[NOTE]
+====
+For *email* notifications, if an organization contact email is set, the test notification is routed to that address. Otherwise, email notifications default to organization administrators. For Slack, webhook, and other methods, routing follows the notification `config`.
+====

--- a/modules/creating-quota-notifications-api.adoc
+++ b/modules/creating-quota-notifications-api.adoc
@@ -9,6 +9,10 @@
 [role="_abstract"]
 You can create and manage quota notifications for organization and user namespaces.
 
+Warning-type quota limits trigger `quota_warning` notifications. Reject-type quota limits trigger `quota_error` notifications. For organization email notifications, `"config": {}` is valid because recipients are resolved server-side (organization contact email, or organization administrators if unset). User email notifications are sent to the user account email address.
+
+{productname} throttles repeated alerts for the same namespace and threshold by using `QUOTA_NOTIFICATION_COOLDOWN_SECONDS` (default: 86400 / 24 hours). If usage drops below a threshold and later crosses it again, the notification can re-fire. Deleting a quota also removes associated `quota_warning` and `quota_error` notification rules for that namespace.
+
 .Prerequisites
 
 * You have link:https://access.redhat.com/documentation/en-us/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#creating-oauth-access-token[Created an OAuth access 

--- a/modules/deleting-quota-notifications.adoc
+++ b/modules/deleting-quota-notifications.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 To permanently stop tracking storage thresholds or decommission an inactive alerting endpoint, you can delete quota notifications from your organization or user namespaces.
 
+[NOTE]
+====
+Deleting a namespace quota also automatically deletes associated `quota_warning` and `quota_error` notification rules for that namespace. After you recreate a quota, you must create new notification rules.
+====
+
 .Procedure
 
 . Delete an organization notification by entering a command similar to the following example:

--- a/modules/quota-configurations-ui.adoc
+++ b/modules/quota-configurations-ui.adoc
@@ -30,8 +30,8 @@ FEATURE_QUOTA_NOTIFICATIONS: true
 
 . Select one of the following notification events:
 +
-* *Quota Warning*: Triggers when storage usage crosses a warning threshold.
-* *Quota Error*: Triggers when storage usage crosses a reject threshold.
+* *Quota Warning*: Triggers when storage usage crosses a *Warning* quota limit (`quota_warning` event).
+* *Quota Error*: Triggers when storage usage crosses a *Reject* quota limit (`quota_error` event).
 
 . Select one of the following notification methods:
 +

--- a/modules/resetting-quota-notifications.adoc
+++ b/modules/resetting-quota-notifications.adoc
@@ -11,13 +11,24 @@ You can resume delivery on a notification channel that has been automatically su
 
 .Procedure
 
-* To reset the failure count to 0, enter a command similar to the following example:
+. To reset an organization notification failure count to `0`, enter a command similar to the following example:
 +
 [source,terminal]
 ----
 $ curl -X POST \
 -H "Authorization: Bearer <bearer_token>" \
 https://<quay-server.example.com>/api/v1/organization/<orgname>/notifications/<uuid>
+----
++
+A successful request returns HTTP `204` with an empty body.
+
+. To reset a user namespace notification failure count to `0`, enter a command similar to the following example:
++
+[source,terminal]
+----
+$ curl -X POST \
+-H "Authorization: Bearer <bearer_token>" \
+https://<quay-server.example.com>/api/v1/user/namespacenotifications/<uuid>
 ----
 +
 A successful request returns HTTP `204` with an empty body.


### PR DESCRIPTION
## Summary
Follow-up to merged [#1685](https://github.com/quay/quay-docs/pull/1685) based on the [review PDF on that PR](https://github.com/quay/quay-docs/pull/1685#issuecomment-5063984794). Focuses on user-facing accuracy and gaps that remained after merge.

Replaces closed [#1721](https://github.com/quay/quay-docs/pull/1721) after renaming the head branch.

- **Fix broken API reference modules:** `testOrgNotification` had user-test content; restore org test docs, add missing `testUserNamespaceNotification`, remove stray `getOrgNotification.adoc.adoc`
- **Event mapping:** Warning limits → `quota_warning`; Reject limits → `quota_error` (procedure + UI)
- **Operational behavior:** cooldown/re-fire, quota-delete cascade removing notification rules
- **Email routing:** clarify empty `config: {}` for user email; scope test-notification routing notes to email methods
- **User parity:** reset procedure includes user namespace endpoint; fix user reset auth to `user:admin`
- **Config:** improve `QUOTA_NOTIFICATION_WORKER_POLL_PERIOD` description; fix YAML `300s` → `300`

## Test plan
- [x] Validated create/list/test/reset/delete for org + user namespace notification endpoints against Quay 3.18
- [x] Confirmed quota-delete cascade removes `quota_warning` / `quota_error` rules
- [ ] Confirm `api_reference` includes both org and user `/test` modules without missing-file includes
- [ ] Spot-check create/reset/delete/email-routing procedures for the new notes
- [ ] Confirm config YAML example uses integer `300`
