### PR TITLE
Add missing 3.18.0 bug fixes from RHSA-2026:48085

### DIFF
--- a/modules/bug-fixes-318.adoc
+++ b/modules/bug-fixes-318.adoc
@@ -143,3 +143,103 @@ With this release, the log rotate worker runs correctly after upgrade.
 * link:https://issues.redhat.com/browse/PROJQUAY-12197[*PROJQUAY-12197*]. Previously, Clair could fail to pull the upstream vulnerability database, which prevented vulnerability reports for scanned images.
 +
 With this release, Clair can update its vulnerability database from upstream sources.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12221[*PROJQUAY-12221*]. Previously, the Superuser *Change Log* page in the new UI failed to load and returned HTTP `502` because `CHANGELOG.md` was missing from the container image.
++
+With this release, the Change Log page loads successfully.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11931[*PROJQUAY-11931*]. Previously, the Superuser *Change Log* page in the new UI showed stale {productname} 3.11.0 content instead of notes for the current release.
++
+With this release, the Change Log page displays content for the current release.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12369[*PROJQUAY-12369*]. Previously, Slack quota warning and error notifications used broken bold formatting and omitted usage data such as consumed and free storage.
++
+With this release, Slack quota notifications render correctly and include usage details.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12232[*PROJQUAY-12232*]. Previously, audit and usage logs showed *No description available* for namespace notification actions.
++
+With this release, namespace notification actions include usable descriptions in the logs.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12229[*PROJQUAY-12229*]. Previously, the namespace notifications table in the UI truncated the *Title* and *Status* column headers.
++
+With this release, those column headers display fully.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12005[*PROJQUAY-12005*]. Previously, the repository mirror health API returned stale data, with fields such as active workers, pending tags, and last sync often reported as zero or null.
++
+With this release, the mirror health API returns current mirror status data.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11892[*PROJQUAY-11892*]. Previously, repository mirror metrics were not available in the {ocp} web console *Monitoring* metrics views after you enabled mirroring metrics.
++
+With this release, repository mirror metrics appear in the {ocp} monitoring metrics UI.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11889[*PROJQUAY-11889*]. Previously, the global sidebar remained visible on repository detail pages in the new UI, which reduced the usable content width.
++
+With this release, repository detail pages use the available width without the global sidebar taking space from the main content area.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11577[*PROJQUAY-11577*]. Previously, the usage logs chart legend in the new UI overlapped the chart area and made both the legend and chart hard to read.
++
+With this release, the legend no longer overlaps the chart.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10605[*PROJQUAY-10605*]. Previously, the *Repository* field in usage logs duplicated namespace information.
++
+With this release, the *Repository* field shows the repository path without duplicated namespace text.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10795[*PROJQUAY-10795*]. Previously, the *Load More Logs* button flashed repeatedly while usage logs were loading.
++
+With this release, the *Load More Logs* control remains stable while logs load.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11079[*PROJQUAY-11079*]. Previously, the `change_tag_immutability` action was missing from the usage logs chart in the new UI.
++
+With this release, tag immutability changes appear in the usage logs chart.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11025[*PROJQUAY-11025*]. Previously, the organization mirror *Schedule* or *Pending* state in the UI did not stay consistent with the related dropdown controls.
++
+With this release, the organization mirror schedule state matches the dropdown selection.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11217[*PROJQUAY-11217*]. Previously, searching for a repository that did not exist left a circular loading spinner on the page indefinitely.
++
+With this release, a search for a missing repository completes and no longer spins forever.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11218[*PROJQUAY-11218*]. Previously, selecting a permission in the permissions dropdown in Firefox navigated to a temporary site unavailable page.
++
+With this release, selecting a permission in Firefox works without that navigation failure.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11219[*PROJQUAY-11219*]. Previously, text entered in the repository filter could appear in unrelated places in the UI.
++
+With this release, repository filter text remains in the filter field.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11257[*PROJQUAY-11257*]. Previously, the branding logo on the new UI login page could be invisible.
++
+With this release, the login page branding logo displays correctly.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-12151[*PROJQUAY-12151*]. Previously, wizard panels could overflow their modal windows when creating a robot account, team, or build trigger.
++
+With this release, those wizard panels fit within the modal.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9246[*PROJQUAY-9246*]. Previously, the new UI did not allow selecting all OAuth applications in bulk.
++
+With this release, you can select all OAuth applications from the list.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9256[*PROJQUAY-9256*]. Previously, you could not clear the default *Skopeo timeout interval* value and enter a new value in the UI.
++
+With this release, you can clear and replace the Skopeo timeout interval value.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9883[*PROJQUAY-9883*]. Previously, the filter on the Superuser *Service Keys* panel did not work.
++
+With this release, filtering service keys works as expected.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11314[*PROJQUAY-11314*]. Previously, the Quay mirror registry installer did not fail when the configured hostname did not meet DNS requirements, which could lead to a broken installation.
++
+With this release, installation fails early when the hostname is not DNS-compliant.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-5075[*PROJQUAY-5075*]. Previously, startup validation could fail when a non-preferred storage engine was unavailable, even if the preferred storage engine was healthy.
++
+With this release, startup continues when the preferred storage engine is available.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10845[*PROJQUAY-10845*]. Previously, {productname} could send non-image artifacts for vulnerability scanning.
++
+With this release, non-image artifacts are not submitted for scanning.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11433[*PROJQUAY-11433*]. Previously, repository `UPDATE` queries during namespace deletion could take many seconds and slow large deletions.
++
+With this release, those database updates complete more efficiently during namespace deletion.

--- a/modules/bug-fixes-318.adoc
+++ b/modules/bug-fixes-318.adoc
@@ -152,30 +152,6 @@ With this release, the Change Log page loads successfully.
 +
 With this release, the Change Log page displays content for the current release.
 
-* link:https://issues.redhat.com/browse/PROJQUAY-12369[*PROJQUAY-12369*]. Previously, Slack quota warning and error notifications used broken bold formatting and omitted usage data such as consumed and free storage.
-+
-With this release, Slack quota notifications render correctly and include usage details.
-
-* link:https://issues.redhat.com/browse/PROJQUAY-12232[*PROJQUAY-12232*]. Previously, audit and usage logs showed *No description available* for namespace notification actions.
-+
-With this release, namespace notification actions include usable descriptions in the logs.
-
-* link:https://issues.redhat.com/browse/PROJQUAY-12229[*PROJQUAY-12229*]. Previously, the namespace notifications table in the UI truncated the *Title* and *Status* column headers.
-+
-With this release, those column headers display fully.
-
-* link:https://issues.redhat.com/browse/PROJQUAY-12005[*PROJQUAY-12005*]. Previously, the repository mirror health API returned stale data, with fields such as active workers, pending tags, and last sync often reported as zero or null.
-+
-With this release, the mirror health API returns current mirror status data.
-
-* link:https://issues.redhat.com/browse/PROJQUAY-11892[*PROJQUAY-11892*]. Previously, repository mirror metrics were not available in the {ocp} web console *Monitoring* metrics views after you enabled mirroring metrics.
-+
-With this release, repository mirror metrics appear in the {ocp} monitoring metrics UI.
-
-* link:https://issues.redhat.com/browse/PROJQUAY-11889[*PROJQUAY-11889*]. Previously, the global sidebar remained visible on repository detail pages in the new UI, which reduced the usable content width.
-+
-With this release, repository detail pages use the available width without the global sidebar taking space from the main content area.
-
 * link:https://issues.redhat.com/browse/PROJQUAY-11577[*PROJQUAY-11577*]. Previously, the usage logs chart legend in the new UI overlapped the chart area and made both the legend and chart hard to read.
 +
 With this release, the legend no longer overlaps the chart.
@@ -247,3 +223,35 @@ With this release, those database updates complete more efficiently during names
 * link:https://issues.redhat.com/browse/PROJQUAY-11691[*PROJQUAY-11691*]. Previously, needless permission checks slowed critical UI API paths. On LDAP-backed installations this could delay or prevent the UI from loading.
 +
 With this release, UI permission checks are optimized so the interface loads reliably, including on LDAP-backed deployments.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-9668[*PROJQUAY-9668*]. Previously, excessive LDAP queries during login could cause timeouts and prevent users from signing in.
++
+With this release, LDAP login query volume is reduced so users can authenticate reliably.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10426[*PROJQUAY-10426*]. Previously, {productname} executed an excessive number of LDAP binds against an empty registry during initial login and username confirmation.
++
+With this release, LDAP bind volume during login is reduced.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10315[*PROJQUAY-10315*]. Previously, pulling images from a proxy cache organization could fail with HTTP `404` even when the image should have been served from cache.
++
+With this release, proxy cache pulls succeed when the cached image is available.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10625[*PROJQUAY-10625*]. Previously, automatic redirects for repository and organization URLs worked in UI v1 but failed in UI v2.
++
+With this release, repository and organization URL redirects work in the new UI.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-10844[*PROJQUAY-10844*]. Previously, teams with more than 20 members could not paginate beyond the first 20 members in UI v2 because the next-page control stayed disabled.
++
+With this release, team member pagination works for teams larger than 20 members.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11235[*PROJQUAY-11235*]. Previously, the *Generate Access Token* page called external CDN resources and Google Fonts, which delayed the page in air-gapped environments.
++
+With this release, generating an access token no longer depends on those external resources.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11375[*PROJQUAY-11375*]. Previously, the Operator continuously recreated the calculated config secret about once per minute even when configuration had not changed.
++
+With this release, the Operator no longer recreates the config secret on every reconcile when nothing has changed.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-1920[*PROJQUAY-1920*]. Previously, a config-tool OIDC validation bug could prevent the registry from starting when a custom OIDC provider was configured.
++
+With this release, OIDC validation no longer blocks registry startup for valid custom OIDC configurations.

--- a/modules/bug-fixes-318.adoc
+++ b/modules/bug-fixes-318.adoc
@@ -243,3 +243,7 @@ With this release, non-image artifacts are not submitted for scanning.
 * link:https://issues.redhat.com/browse/PROJQUAY-11433[*PROJQUAY-11433*]. Previously, repository `UPDATE` queries during namespace deletion could take many seconds and slow large deletions.
 +
 With this release, those database updates complete more efficiently during namespace deletion.
+
+* link:https://issues.redhat.com/browse/PROJQUAY-11691[*PROJQUAY-11691*]. Previously, needless permission checks slowed critical UI API paths. On LDAP-backed installations this could delay or prevent the UI from loading.
++
+With this release, UI permission checks are optimized so the interface loads reliably, including on LDAP-backed deployments.


### PR DESCRIPTION
## Summary
- Compared `bug-fixes-318.adoc` against [RHSA-2026:48085](https://access.redhat.com/errata/RHSA-2026:48085) / [konflux PR #226](https://github.com/quay/quay-konflux-configs/pull/226)
- Added 25 customer-facing bug-fix entries that were on the advisory but missing from the release notes
- Left features/enhancements, CVEs/image rebuilds, internal CI/dev work, and operator refactors out of this module (those are covered elsewhere or not RN-worthy as bug fixes)

## Test plan
- [ ] Spot-check a few new bullets against Jira for accuracy
- [ ] Confirm feature-tracker / new-features modules already cover skipped feature epics (mirror metrics, cert-manager, Entra, quota notifications feature, etc.)


Made with [Cursor](https://cursor.com)