### PR TITLE
Fix broken Surge Preview Deploy workflow YAML

### DIFF
--- a/.github/workflows/surge-preview-deploy.yaml
+++ b/.github/workflows/surge-preview-deploy.yaml
@@ -9,11 +9,15 @@ jobs:
   deploy:
     name: Deploy to Surge
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.event == 'pull_request'
+    # Only deploy successful PR builds. workflow_run always uses this file from the default branch.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
 
     permissions:
-      pull-requests: write
+      actions: read
       contents: read
+      pull-requests: write
 
     steps:
     - name: Download build artifact
@@ -35,7 +39,7 @@ jobs:
       run: |
         DEPLOY_DOMAIN="quay-docs-pr-${{ steps.pr.outputs.number }}.surge.sh"
         cd dist
-        npx surge . $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+        npx surge . "$DEPLOY_DOMAIN" --token "${{ secrets.SURGE_TOKEN }}"
         echo "url=https://$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
       env:
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -48,6 +52,7 @@ jobs:
           const path = require('path');
           const deploymentUrl = '${{ steps.deploy.outputs.url }}';
           const prNumber = ${{ steps.pr.outputs.number }};
+          const headSha = '${{ github.event.workflow_run.head_sha }}';
 
           const { data: files } = await github.rest.pulls.listFiles({
             owner: context.repo.owner,
@@ -56,18 +61,32 @@ jobs:
             per_page: 100,
           });
 
-          // Map changed top-level book dirs to preview paths (flat + directory).
+          // Map changed book dirs to preview paths (flat + directory).
+          // Supports legacy top-level books and JTBD books under quay_jtbd/<category>/.
           const previewPaths = new Set();
           for (const file of files) {
-            if (file.filename === 'welcome.adoc') {
+            if (file.filename === 'welcome.adoc' || file.filename === 'build_docs') {
               previewPaths.add('/');
               continue;
             }
-            const top = file.filename.split('/')[0];
-            let book = top === 'api' ? 'api_quay' : top;
-            if (fs.existsSync(path.join('dist', `${book}.html`))) {
-              previewPaths.add(`/${book}.html`);
-              previewPaths.add(`/${book}/`);
+            const parts = file.filename.split('/');
+            const top = parts[0];
+            let flat;
+            let dirPath;
+            if (top === 'quay_jtbd' && parts.length >= 2) {
+              const cat = parts[1];
+              flat = `quay_jtbd-${cat}`;
+              dirPath = `quay_jtbd/${cat}`;
+            } else {
+              const book = top === 'api' ? 'api_quay' : top;
+              flat = book;
+              dirPath = book;
+            }
+            if (fs.existsSync(path.join('dist', `${flat}.html`))) {
+              previewPaths.add(`/${flat}.html`);
+            }
+            if (fs.existsSync(path.join('dist', dirPath, 'index.html'))) {
+              previewPaths.add(`/${dirPath}/`);
             }
           }
 
@@ -91,15 +110,18 @@ jobs:
             comment.body.includes('Surge Preview Deployment')
           );
 
-          const commentBody = `## Surge Preview Deployment
-
-✅ **Preview deployed successfully!**
-
-🔗 **Preview URL:** ${deploymentUrl}
-${bookLinks}
-Built from commit ${{ github.event.workflow_run.head_sha }}
-
-_This preview will be updated on every push to this PR._`;
+          // Keep every line of this template indented so the YAML `|` block stays valid.
+          const commentBody = [
+            '## Surge Preview Deployment',
+            '',
+            '✅ **Preview deployed successfully!**',
+            '',
+            `🔗 **Preview URL:** ${deploymentUrl}`,
+            bookLinks,
+            `Built from commit ${headSha}`,
+            '',
+            '_This preview will be updated on every push to this PR._',
+          ].join('\n');
 
           if (botComment) {
             await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary
- Fixes invalid YAML in `.github/workflows/surge-preview-deploy.yaml` introduced by #1704 (comment body dedented to column 0, terminating the `script: |` block).
- That breakage stopped `workflow_run` deploys, so Surge previews have not been publishing (including #1737).
- Also requires `workflow_run.conclusion == success` and adds `actions: read` for artifact download.

## Test plan
- [ ] Confirm this workflow file parses (Actions no longer reports the deploy workflow as path-only / empty-job failures)
- [ ] Re-run **Surge Preview Build** on an open PR (e.g. #1737) and confirm **Surge Preview Deploy** runs
- [ ] Confirm `https://quay-docs-pr-<n>.surge.sh` returns 200 and a bot comment appears on the PR


Made with [Cursor](https://cursor.com)