### PR TITLE
Adds 3.15.7 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.15
-:productminv: v3.15.6
+:productminv: v3.15.7
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productversion: 3
 :producty: 3.15
 :producty-n1: 3.14
-:productmin: 3.15.6
-:productminv: v3.15.6
+:productmin: 3.15.7
+:productminv: v3.15.7
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn-3-15-7.adoc
+++ b/modules/rn-3-15-7.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: REFERENCE
+[id="rn-3-15-7"]
+= RHSA-2026:48933 - {productname} 3.15.7 release
+
+Issued 2026-07-30
+
+[role="_abstract"]
+{productname} release 3.15.7 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:48933[RHSA-2026:48933] advisory.
+

--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -33,6 +33,7 @@ endif::downstream[]
 
 
 include::modules/rn_overview.adoc[leveloffset=+1]
+include::modules/rn-3-15-7.adoc[leveloffset=+2]
 include::modules/rn-3-15-6.adoc[leveloffset=+2]
 include::modules/rn-3-15-4.adoc[leveloffset=+2]
 include::modules/rn-3-15-3.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.15.7 (advisory-only; CVE/internal fixes not documented)
- Source: https://github.com/quay/quay-konflux-configs/pull/258
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12755

## Skipped (not documented)
- All konflux fixed issues are CVE-only or Red Hat Employee security level.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.15.7
- [ ] Vale / AsciiDoc build clean on redhat-3.15

Made with [Cursor](https://cursor.com)