### PR TITLE
Adds 3.9.25 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -15,7 +15,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.9
-:productminv: v3.9.24
+:productminv: v3.9.25
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -31,8 +31,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.9
-:productmin: 3.9.24
-:productminv: v3.9.24
+:productmin: 3.9.25
+:productminv: v3.9.25
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_90.adoc
+++ b/modules/rn_3_90.adoc
@@ -5,6 +5,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+
+[id="rn-3-9025"]
+== RHSA-2026:50931 - {productname} 3.9.25 release
+
+Issued 2026-08-05
+
+{productname} release 3.9.25 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:50931[RHSA-2026:50931] advisory.
+
 [id="rn-3-9024"]
 == RHSA-2026:40262 - {productname} 3.9.24 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.9.25 (advisory-only; CVE/internal fixes not documented)
- Source: https://github.com/quay/quay-konflux-configs/pull/264
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12756

## Skipped (not documented)
- All konflux fixed issues are CVE-only or Red Hat Employee security level.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.9.25
- [ ] Vale / AsciiDoc build clean on redhat-3.9

Made with [Cursor](https://cursor.com)