### PR TITLE
Adds 3.12.21 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.12
-:productminv: v3.12.20
+:productminv: v3.12.21
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.12
-:productmin: 3.12.20
-:productminv: v3.12.20
+:productmin: 3.12.21
+:productminv: v3.12.21
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_12.adoc
+++ b/modules/rn_3_12.adoc
@@ -4,6 +4,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+
+[id="rn-3-12-21"]
+== RHSA-2026:52968 - {productname} 3.12.21 release
+
+Issued 2026-08-10
+
+{productname} release 3.12.21 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:52968[RHSA-2026:52968] advisory.
+
 [id="rn-3-12-20"]
 == RHSA-2026:43052 - {productname} 3.12.20 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.12.21 (advisory-only; CVE/internal fixes not documented)
- Source: https://github.com/quay/quay-konflux-configs/pull/260
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12757

## Skipped (not documented)
- All konflux fixed issues are CVE-only or Red Hat Employee security level.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.12.21
- [ ] Vale / AsciiDoc build clean on redhat-3.12

Made with [Cursor](https://cursor.com)