### PR TITLE
Adds 3.10.25 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.10
-:productminv: v3.10.24
+:productminv: v3.10.25
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -33,8 +33,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.10
-:productmin: 3.10.24
-:productminv: v3.10.24
+:productmin: 3.10.25
+:productminv: v3.10.25
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -4,6 +4,14 @@
 
 The following sections detail _y_ and _z_ stream release information.
 
+
+[id="rn-3-10-25"]
+== RHSA-2026:53520 - {productname} 3.10.25 release
+
+Issued 2026-08-11
+
+{productname} release 3.10.25 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:53520[RHSA-2026:53520] advisory.
+
 [id="rn-3-10-24"]
 == RHSA-2026:41031 - {productname} 3.10.24 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.10.25 (advisory-only; CVE/internal fixes not documented)
- Source: https://github.com/quay/quay-konflux-configs/pull/263
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12758

## Skipped (not documented)
- All konflux fixed issues are CVE-only or Red Hat Employee security level.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.10.25
- [ ] Vale / AsciiDoc build clean on redhat-3.10

Made with [Cursor](https://cursor.com)