### PR TITLE
Adds 3.17.4 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.17
-:productminv: v3.17.3
+:productminv: v3.17.4
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productversion: 3
 :producty: 3.17
 :producty-n1: 3.16
-:productmin: 3.17.3
-:productminv: v3.17.3
+:productmin: 3.17.4
+:productminv: v3.17.4
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel9
 :clairimage: clair-rhel9

--- a/modules/rn-3-17-4.adoc
+++ b/modules/rn-3-17-4.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: REFERENCE
+[id="rn-3-17-4"]
+= RHSA-2026:54395 - {productname} 3.17.4 release
+
+Issued 2026-08-12
+
+[role="_abstract"]
+{productname} release 3.17.4 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:54395[RHSA-2026:54395] advisory.
+

--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -33,6 +33,7 @@ endif::downstream[]
 
 
 include::modules/rn_overview.adoc[leveloffset=+1]
+include::modules/rn-3-17-4.adoc[leveloffset=+2]
 include::modules/rn-3-17-3.adoc[leveloffset=+2]
 include::modules/rn-3-17-2.adoc[leveloffset=+2]
 include::modules/rn-3-17-1.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.17.4 (advisory-only; CVE/internal fixes not documented)
- Source: https://github.com/quay/quay-konflux-configs/pull/265
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12759

## Skipped (not documented)
- All konflux fixed issues are CVE-only or Red Hat Employee security level.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata
- [ ] Attributes updated to 3.17.4
- [ ] Vale / AsciiDoc build clean on redhat-3.17

Made with [Cursor](https://cursor.com)