### PR TITLE
Add JTBD product navigation MAP for unified Surge preview

### DIFF
--- a/.github/workflows/surge-preview-deploy.yaml
+++ b/.github/workflows/surge-preview-deploy.yaml
@@ -65,8 +65,13 @@ jobs:
           // Supports legacy top-level books and JTBD books under quay_jtbd/<category>/.
           const previewPaths = new Set();
           for (const file of files) {
-            if (file.filename === 'welcome.adoc' || file.filename === 'build_docs') {
+            if (file.filename === 'welcome.adoc' || file.filename === 'build_docs' || file.filename === 'build_docs_preview') {
               previewPaths.add('/');
+              continue;
+            }
+            if (file.filename === 'quay-3-18-navigation.adoc') {
+              previewPaths.add('/quay-3-18-navigation.html');
+              previewPaths.add('/quay_jtbd-navigation/');
               continue;
             }
             const parts = file.filename.split('/');

--- a/build_docs
+++ b/build_docs
@@ -43,4 +43,9 @@ if [[ -d quay_jtbd ]]; then
   done
 fi
 
+# JTBD product navigation MAP (category MAP → job ASSEMBLY → modules)
+if [[ -f quay-3-18-navigation.adoc ]]; then
+  build_master "quay-3-18-navigation.adoc" "quay_jtbd-navigation" "quay-3-18-navigation" "images"
+fi
+
 cp -a images dist/images

--- a/build_docs_preview
+++ b/build_docs_preview
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build Surge preview with redhat-docs-template styling (asciidoctor + left-nav theme).
-# Supports legacy top-level books and JTBD category books under quay_jtbd/.
+# Supports legacy top-level books, JTBD category books, and the product navigation MAP.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -138,6 +138,11 @@ if [[ -d quay_jtbd ]]; then
     dir=$(basename "$(dirname "$master")")
     build_book "$master" "quay_jtbd/${dir}" "quay_jtbd-${dir}" "../../images" "../../assets/css" 2
   done
+fi
+
+echo "=== Building JTBD product navigation MAP ==="
+if [[ -f quay-3-18-navigation.adoc ]]; then
+  build_book "quay-3-18-navigation.adoc" "quay_jtbd-navigation" "quay-3-18-navigation" "images" "assets/css" 1
 fi
 
 cp -a images dist/images

--- a/modules/helm-oci-quay.adoc
+++ b/modules/helm-oci-quay.adoc
@@ -90,3 +90,4 @@ Example output:
 Pulled: quay370.apps.quayperf370.perfscale.devcluster.openshift.com/etherpad:0.0.4
 Digest: sha256:4f627399685880daf30cf77b6026dc129034d68c7676c7e07020b70cf7130902
 ----
+endif::[]

--- a/quay-3-18-navigation.adoc
+++ b/quay-3-18-navigation.adoc
@@ -1,0 +1,39 @@
+:_mod-docs-content-type: MAP
+include::_attributes/attributes.adoc[]
+:toc:
+:toclevels: 4
+= {productname} navigation
+
+include::quay_jtbd/whats_new/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/discover/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/get_started/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/plan/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/install/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/upgrade/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/migrate/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/administer/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/develop/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/configure/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/secure/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/observe/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/integrate/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/optimize/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/extend/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/troubleshoot/master.adoc[leveloffset=+1]
+
+include::quay_jtbd/reference/master.adoc[leveloffset=+1]

--- a/quay_jtbd/README.adoc
+++ b/quay_jtbd/README.adoc
@@ -14,6 +14,17 @@ Each product documentation category is a book:
 
 Category order and module placement come from `JTBD draft 11.pre-gapfill.xlsx`.
 
+== Product navigation MAP
+
+The AEM migration root ditamap is `quay-3-18-navigation.adoc` at the repository root. It includes all 17 category MAPs (`quay_jtbd/*/master.adoc`) at `leveloffset=+1` in the same order as `welcome.adoc`.
+
+After `build_docs` or `build_docs_preview` runs, the unified navigation preview is:
+
+* `/quay-3-18-navigation.html` (flat HTML)
+* `/quay_jtbd-navigation/` (directory index)
+
+Individual category books remain available for focused review and for cross-book xrefs in Surge previews.
+
 == Job assemblies and navigation
 
 * Category `master.adoc` files use `:_mod-docs-content-type: MAP` and include job assemblies at `leveloffset=+1`.

--- a/welcome.adoc
+++ b/welcome.adoc
@@ -8,6 +8,9 @@ include::_attributes/attributes.adoc[]
 
 This preview reorganizes {productname} documentation by Jobs-to-be-Done categories.
 
+xref:quay-3-18-navigation.adoc[Full JTBD navigation preview]::
+  Browse all JTBD categories and jobs in a single left-hand navigation tree (AEM migration root MAP).
+
 xref:quay_jtbd-whats_new.adoc[What's new]::
   Learn what has changed in the current Red Hat Quay release.
 


### PR DESCRIPTION
## Summary
- Add `quay-3-18-navigation.adoc` as the AEM migration root MAP, including all 17 JTBD category MAPs at `leveloffset=+1` in the same order as `welcome.adoc`.
- Wire `build_docs` and `build_docs_preview` to emit `/quay-3-18-navigation.html` and `/quay_jtbd-navigation/`, link the unified preview from `welcome.adoc`, and surface it in Surge PR comments.
- Fix a missing `endif::[]` in `modules/helm-oci-quay.adoc` that prevented the combined navigation book from building through Troubleshoot and Reference.

## Test plan
- [ ] Run `./build_docs_preview` locally and confirm exit 0
- [ ] Open Surge preview `/quay-3-18-navigation.html` and verify LHS includes all 17 categories through Reference
- [ ] Spot-check Configure, Install, and Develop sections in the unified nav
- [ ] Confirm welcome page link to full JTBD navigation preview works
- [ ] Verify individual category previews (`quay_jtbd-*.html`) still build


Made with [Cursor](https://cursor.com)