### PR TITLE
Fix Reference book build errors

### DIFF
--- a/modules/api-referrers-getReferrers.adoc
+++ b/modules/api-referrers-getReferrers.adoc
@@ -24,7 +24,4 @@ _required_|The full path of the repository. e.g. namespace/name|string
 |path|**referrers**
  
 _required_| Looks up the OCI referrers of a manifest under a repository.|string
-|**manifest_digest**
- 
-_required_|The digest of the manifest|string
 |===

--- a/modules/api-robot-deleteOrgRobotFederation.adoc
+++ b/modules/api-robot-deleteOrgRobotFederation.adoc
@@ -1,0 +1,46 @@
+:_mod-docs-content-type: REFERENCE
+[id="deleteorgrobotfederation"]
+= deleteOrgRobotFederation
+
+[role="_abstract"]
+Delete the federation configuration for the specified organization robot.
+
+[id="deleteorgrobotfederation-delete"]
+== DELETE /api/v1/organization/{orgname}/robots/{robot_shortname}/federation
+
+Delete the federation configuration for the specified organization robot.
+
+**Authorizations: **oauth2_implicit (**user:admin**)
+
+[id="deleteorgrobotfederation-path-parameters"]
+== Path parameters
+
+[options="header", width=100%, cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|path|*orgname* + *robot_shortname*
+_required_|The name of the organization and the short name for the robot, without any user or organization prefix|string
+|===
+
+[id="deleteorgrobotfederation-responses"]
+== Responses
+
+[options="header", width=100%, cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|204|Deleted|
+|400|Bad Request|&lt;&lt;_apierror,ApiError&gt;&gt;
+|401|Session required|&lt;&lt;_apierror,ApiError&gt;&gt;
+|403|Unauthorized access|&lt;&lt;_apierror,ApiError&gt;&gt;
+|404|Not found|&lt;&lt;_apierror,ApiError&gt;&gt;
+|===
+
+[id="deleteorgrobotfederation-example-command"]
+== Example command
+
+[source,terminal]
+----
+$ curl -X DELETE \
+  -H "Authorization: Bearer <bearer_token>" \
+  "https://quay-server.example.com/api/v1/organization/{orgname}/robots/{robot_shortname}/federation"
+----


### PR DESCRIPTION
## Summary
- Add `modules/api-robot-deleteOrgRobotFederation.adoc` for the DELETE federation endpoint referenced from `quay_jtbd/reference/api-robot-part-2.adoc`.
- Fix `modules/api-referrers-getReferrers.adoc` by removing a malformed fourth table row that caused AsciiDoc to drop cells at end of table.

## Test plan
- [ ] `./build_docs_preview` completes with no `asciidoctor: ERROR` lines
- [ ] `asciidoctor quay_jtbd/reference/master.adoc` builds cleanly
- [ ] Spot-check `/quay_jtbd-reference.html` robot (part 2) and referrers sections in Surge preview


Made with [Cursor](https://cursor.com)