### PR TITLE
Move SSL config fields Additional resources to module end

### DIFF
--- a/modules/config-fields-ssl.adoc
+++ b/modules/config-fields-ssl.adoc
@@ -5,11 +5,6 @@
 [role="_abstract"]
 Configure SSL/TLS settings, hostname, cipher suites, and session cookie security for {productname}.
 
-This section describes the available configuration fields for enabling and managing SSL/TLS encryption in your {productname} deployment.
-
-.Additional resources
-* xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}]
-
 .SSL configuration fields
 [cols="3a,1a,2a",options="header"]
 |===
@@ -37,3 +32,8 @@ SESSION_COOKIE_SECURE: true
 EXTERNAL_TLS_TERMINATION: true
 # ...
 ----
+
+[id="additional-resources"]
+.Additional resources
+
+* xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}]


### PR DESCRIPTION
## Summary
- Restores stashed WIP on `modules/config-fields-ssl.adoc`.
- Removes redundant intro sentence (covered by the abstract).
- Moves **Additional resources** (xref to Secure SSL/TLS overview) to the end of the module, after the field table and YAML example.

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Configure SSL/TLS field reference job in Surge preview
- [ ] Confirm xref to `quay_jtbd-secure.adoc#ssl-tls-quay-overview` resolves


Made with [Cursor](https://cursor.com)