### PR TITLE
Add Secure job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/secure/master.adoc
+++ b/quay_jtbd/secure/master.adoc
@@ -4,10 +4,10 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Configure SSL/TLS for standalone Red Hat Quay
-include::configure-ssl-tls-for-standalone-red-hat-quay.adoc[leveloffset=+1]
+include::configure-ssl-tls-for-standalone-red-hat-quay.adoc[leveloffset=+1,navtitle="Standalone SSL/TLS"]
 
 // Job: Configure SSL/TLS for Quay on OpenShift
-include::configure-ssl-tls-for-quay-on-openshift.adoc[leveloffset=+1]
+include::configure-ssl-tls-for-quay-on-openshift.adoc[leveloffset=+1,navtitle="SSL/TLS on OpenShift"]
 
 // Job: Secure database connections with TLS
 include::secure-database-connections-with-tls.adoc[leveloffset=+1]
@@ -19,19 +19,19 @@ include::add-trusted-certificate-authorities.adoc[leveloffset=+1]
 include::authenticate-users-with-ldap.adoc[leveloffset=+1]
 
 // Job: Authenticate users with OIDC and single sign-on
-include::authenticate-users-with-oidc-and-single-sign-on.adoc[leveloffset=+1]
+include::authenticate-users-with-oidc-and-single-sign-on.adoc[leveloffset=+1,navtitle="OIDC and SSO"]
 
 // Job: Eliminate long-lived robot credentials with keyless authentication
-include::eliminate-long-lived-robot-credentials-with-keyless-authentication.adoc[leveloffset=+1]
+include::eliminate-long-lived-robot-credentials-with-keyless-authentication.adoc[leveloffset=+1,navtitle="Keyless robot authentication"]
 
 // Job: Ensure FIPS compliance for the registry
-include::ensure-fips-compliance-for-the-registry.adoc[leveloffset=+1]
+include::ensure-fips-compliance-for-the-registry.adoc[leveloffset=+1,navtitle="FIPS compliance"]
 
 // Job: Set repository permissions and visibility
 include::set-repository-permissions-and-visibility.adoc[leveloffset=+1]
 
 // Job: Manage registry-wide and team access policies
-include::manage-registry-wide-and-team-access-policies.adoc[leveloffset=+1]
+include::manage-registry-wide-and-team-access-policies.adoc[leveloffset=+1,navtitle="Registry access policies"]
 
 // Job: Review Clair vulnerability scan results
 include::review-clair-vulnerability-scan-results.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Secure category MAP includes for jobs with long page titles. Full assembly titles are unchanged.

| Page title | LHS navtitle |
|------------|--------------|
| Configure SSL/TLS for standalone Red Hat Quay | Standalone SSL/TLS |
| Configure SSL/TLS for {productname-ocp} | SSL/TLS on OpenShift |
| Authenticate users with OIDC and single sign-on | OIDC and SSO |
| Eliminate long-lived robot credentials with keyless authentication | Keyless robot authentication |
| Ensure FIPS compliance for the registry | FIPS compliance |
| Manage registry-wide and team access policies | Registry access policies |

Short titles (LDAP, trusted CAs, database TLS, repository permissions, Clair scans) left unchanged.

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Secure section in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)