### PR TITLE
Add Install job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/install/master.adoc
+++ b/quay_jtbd/install/master.adoc
@@ -4,16 +4,16 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Install {productname-ocp} Container Platform
-include::install-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1]
+include::install-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1,navtitle="Install on {ocp}"]
 
 // Job: Install Red Hat Quay proof of concept
-include::install-red-hat-quay-proof-of-concept.adoc[leveloffset=+1]
+include::install-red-hat-quay-proof-of-concept.adoc[leveloffset=+1,navtitle="Proof of concept"]
 
 // Job: Configure IPv6 for Quay proof of concept
-include::configure-ipv6-for-quay-proof-of-concept.adoc[leveloffset=+2]
+include::configure-ipv6-for-quay-proof-of-concept.adoc[leveloffset=+2,navtitle="PoC IPv6 configuration"]
 
 // Job: Install Red Hat Quay in high availability
-include::install-red-hat-quay-in-high-availability.adoc[leveloffset=+1]
+include::install-red-hat-quay-in-high-availability.adoc[leveloffset=+1,navtitle="High availability"]
 
 // Job: Install Clair for Red Hat Quay
 include::install-clair-for-red-hat-quay.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Install category MAP includes for jobs with long page titles.

| Page title | LHS navtitle |
|------------|--------------|
| Install {productname-ocp} Container Platform | Install on OpenShift |
| Install Red Hat Quay proof of concept | Proof of concept |
| Configure IPv6 for Quay proof of concept | PoC IPv6 configuration |
| Install Red Hat Quay in high availability | High availability |

**Install Clair for Red Hat Quay** left unchanged (already short).

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Install section in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)