### PR TITLE
Add Administer job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/administer/master.adoc
+++ b/quay_jtbd/administer/master.adoc
@@ -4,7 +4,7 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Manage user accounts in the registry
-include::manage-user-accounts-in-the-registry.adoc[leveloffset=+1]
+include::manage-user-accounts-in-the-registry.adoc[leveloffset=+1,navtitle="User accounts"]
 
 // Job: Manage organizations
 include::manage-organizations.adoc[leveloffset=+1]
@@ -16,22 +16,22 @@ include::manage-image-repositories.adoc[leveloffset=+1]
 include::manage-robot-accounts.adoc[leveloffset=+1]
 
 // Job: Organize users into teams for shared access control
-include::organize-users-into-teams-for-shared-access-control.adoc[leveloffset=+1]
+include::organize-users-into-teams-for-shared-access-control.adoc[leveloffset=+1,navtitle="Teams and access control"]
 
 // Job: View and manage image tag information
-include::view-and-manage-image-tag-information.adoc[leveloffset=+1]
+include::view-and-manage-image-tag-information.adoc[leveloffset=+1,navtitle="Tag information"]
 
 // Job: Set tag expiration and retire tags
-include::set-tag-expiration-and-retire-tags.adoc[leveloffset=+1]
+include::set-tag-expiration-and-retire-tags.adoc[leveloffset=+1,navtitle="Tag expiration"]
 
 // Job: Protect image tags with immutability policies
-include::protect-image-tags-with-immutability-policies.adoc[leveloffset=+1]
+include::protect-image-tags-with-immutability-policies.adoc[leveloffset=+1,navtitle="Tag immutability"]
 
 // Job: Configure organization storage quotas
 include::configure-organization-storage-quotas.adoc[leveloffset=+1]
 
 // Job: Enforce quota limits and reclaim storage
-include::enforce-quota-limits-and-reclaim-storage.adoc[leveloffset=+1]
+include::enforce-quota-limits-and-reclaim-storage.adoc[leveloffset=+1,navtitle="Quota enforcement"]
 
 // Job: Enable automatic tag pruning
 include::enable-automatic-tag-pruning.adoc[leveloffset=+1]
@@ -43,7 +43,7 @@ include::create-automatic-tag-pruning-policies.adoc[leveloffset=+1]
 include::reclaim-storage-with-garbage-collection.adoc[leveloffset=+1]
 
 // Job: Back up and restore standalone Red Hat Quay
-include::back-up-and-restore-standalone-red-hat-quay.adoc[leveloffset=+1]
+include::back-up-and-restore-standalone-red-hat-quay.adoc[leveloffset=+1,navtitle="Standalone backup and restore"]
 
 // Job: Back up {productname-ocp}
 include::back-up-red-hat-quay-on-openshift.adoc[leveloffset=+1]
@@ -52,10 +52,10 @@ include::back-up-red-hat-quay-on-openshift.adoc[leveloffset=+1]
 include::restore-red-hat-quay-on-openshift.adoc[leveloffset=+1]
 
 // Job: Perform health checks on Red Hat Quay deployments
-include::perform-health-checks-on-red-hat-quay-deployments.adoc[leveloffset=+1]
+include::perform-health-checks-on-red-hat-quay-deployments.adoc[leveloffset=+1,navtitle="Deployment health checks"]
 
 // Job: Reconfigure the QuayRegistry after deployment
-include::reconfigure-the-quayregistry-after-deployment.adoc[leveloffset=+1]
+include::reconfigure-the-quayregistry-after-deployment.adoc[leveloffset=+1,navtitle="Reconfigure after deployment"]
 
 // Job: Manage geo-replicated sites day-to-day
 include::manage-geo-replicated-sites-day-to-day.adoc[leveloffset=+1]
@@ -64,4 +64,4 @@ include::manage-geo-replicated-sites-day-to-day.adoc[leveloffset=+1]
 include::manage-bootstrap-token-lifecycle.adoc[leveloffset=+1]
 
 // Job: Administer the registry as a superuser
-include::administer-the-registry-as-a-superuser.adoc[leveloffset=+1]
+include::administer-the-registry-as-a-superuser.adoc[leveloffset=+1,navtitle="Superuser administration"]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Administer category MAP includes for jobs with long page titles. Full assembly titles are unchanged.

| Page title | LHS navtitle |
|------------|--------------|
| Manage user accounts in the registry | User accounts |
| Organize users into teams for shared access control | Teams and access control |
| View and manage image tag information | Tag information |
| Set tag expiration and retire tags | Tag expiration |
| Protect image tags with immutability policies | Tag immutability |
| Enforce quota limits and reclaim storage | Quota enforcement |
| Back up and restore standalone Red Hat Quay | Standalone backup and restore |
| Perform health checks on Red Hat Quay deployments | Deployment health checks |
| Reconfigure {productname-ocp} after deployment | Reconfigure after deployment |
| Administer the registry as a superuser | Superuser administration |

Shorter jobs (organizations, repositories, robot accounts, geo-replication, backup/restore on OpenShift, tag pruning, garbage collection, bootstrap tokens) left unchanged.

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Administer section in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)