### PR TITLE
Add Develop job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/develop/master.adoc
+++ b/quay_jtbd/develop/master.adoc
@@ -4,31 +4,31 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Get started with the Red Hat Quay API
-include::get-started-with-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::get-started-with-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Get started with the API"]
 
 // Job: Manage OAuth access tokens for the Red Hat Quay API
-include::manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="OAuth access tokens"]
 
 // Job: Manage robot account tokens for the Red Hat Quay API
-include::manage-robot-account-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::manage-robot-account-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Robot account tokens"]
 
 // Job: Manage OCI referrers OAuth access tokens for the Red Hat Quay API
-include::manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="OCI referrers tokens"]
 
 // Job: Automate organization and quota operations through the Red Hat Quay API
-include::automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Organization and quota automation"]
 
 // Job: Automate repository and robot operations through the Red Hat Quay API
-include::automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Repository and robot automation"]
 
 // Job: Automate tags and teams through the Red Hat Quay API
-include::automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc[leveloffset=+1]
+include::automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Tags, teams, and builds"]
 
 // Job: Build container images from Dockerfiles in Red Hat Quay
-include::build-container-images-from-dockerfiles-in-red-hat-quay.adoc[leveloffset=+1]
+include::build-container-images-from-dockerfiles-in-red-hat-quay.adoc[leveloffset=+1,navtitle="Build from Dockerfiles"]
 
 // Job: Configure build triggers for Red Hat Quay
-include::configure-build-triggers-for-red-hat-quay.adoc[leveloffset=+1]
+include::configure-build-triggers-for-red-hat-quay.adoc[leveloffset=+1,navtitle="Build triggers"]
 
 // Job: Work with OCI artifacts, Helm charts, and image signing
-include::work-with-oci-artifacts-helm-charts-and-image-signing.adoc[leveloffset=+1]
+include::work-with-oci-artifacts-helm-charts-and-image-signing.adoc[leveloffset=+1,navtitle="OCI artifacts and signing"]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on all Develop category MAP includes. Every Develop job has a long page title (most repeat "Red Hat Quay API"); full assembly titles are unchanged.

| Page title | LHS navtitle |
|------------|--------------|
| Get started with the Red Hat Quay API | Get started with the API |
| Manage OAuth access tokens for the Red Hat Quay API | OAuth access tokens |
| Manage robot account tokens for the Red Hat Quay API | Robot account tokens |
| Manage OCI referrers OAuth access tokens for the Red Hat Quay API | OCI referrers tokens |
| Automate organization and quota operations through the Red Hat Quay API | Organization and quota automation |
| Automate repository and robot operations through the Red Hat Quay API | Repository and robot automation |
| Automate tags and teams through the Red Hat Quay API | Tags, teams, and builds |
| Build container images from Dockerfiles in Red Hat Quay | Build from Dockerfiles |
| Configure build triggers for Red Hat Quay | Build triggers |
| Work with OCI artifacts, Helm charts, and image signing | OCI artifacts and signing |

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Develop section in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)