### PR TITLE
Add Plan and Discover job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/administer/manage-geo-replicated-sites-day-to-day.adoc
+++ b/quay_jtbd/administer/manage-geo-replicated-sites-day-to-day.adoc
@@ -5,7 +5,7 @@
 :context: manage_geo_replicated_sites
 
 [role="_abstract"]
-Manage geo-replicated sites by enabling storage preferences, running with replication settings, and adding or removing sites on standalone or OpenShift deployments.
+Manage geo-replicated sites by enabling storage preferences, running with replication settings, and adding or removing sites on standalone or {ocp} deployments.
 
 include::modules/georepl-intro.adoc[leveloffset=+1]
 

--- a/quay_jtbd/discover/master.adoc
+++ b/quay_jtbd/discover/master.adoc
@@ -4,19 +4,19 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Understand Red Hat Quay capabilities and architecture
-include::understand-red-hat-quay-capabilities-and-architecture.adoc[leveloffset=+1]
+include::understand-red-hat-quay-capabilities-and-architecture.adoc[leveloffset=+1,navtitle="Capabilities and architecture"]
 
 // Job: Understand Red Hat Quay infrastructure and governance
-include::understand-red-hat-quay-infrastructure-and-governance.adoc[leveloffset=+1]
+include::understand-red-hat-quay-infrastructure-and-governance.adoc[leveloffset=+1,navtitle="Infrastructure and governance"]
 
 // Job: Evaluate Quay.io as a hosted registry option
-include::evaluate-quay-io-as-a-hosted-registry-option.adoc[leveloffset=+1]
+include::evaluate-quay-io-as-a-hosted-registry-option.adoc[leveloffset=+1,navtitle="Evaluate Quay.io"]
 
 // Job: Understand Red Hat Quay's tenancy model
-include::understand-red-hat-quay-s-tenancy-model.adoc[leveloffset=+1]
+include::understand-red-hat-quay-s-tenancy-model.adoc[leveloffset=+1,navtitle="Tenancy model"]
 
 // Job: Understand the Red Hat Quay permissions model
-include::understand-the-red-hat-quay-permissions-model.adoc[leveloffset=+1]
+include::understand-the-red-hat-quay-permissions-model.adoc[leveloffset=+1,navtitle="Permissions model"]
 
 // Job: Understand Clair vulnerability scanning
 include::understand-clair-vulnerability-scanning.adoc[leveloffset=+1]

--- a/quay_jtbd/plan/master.adoc
+++ b/quay_jtbd/plan/master.adoc
@@ -5,13 +5,13 @@ include::_attributes/attributes.adoc[]
 
 // Foundations
 // Job: Plan supporting infrastructure for Red Hat Quay
-include::plan-red-hat-quay-prerequisites-and-supporting-infrastructure.adoc[leveloffset=+1]
+include::plan-red-hat-quay-prerequisites-and-supporting-infrastructure.adoc[leveloffset=+1,navtitle="Supporting infrastructure"]
 
 // Job: Choose a single registry or multiple registries
-include::choose-a-single-registry-or-multiple-registries.adoc[leveloffset=+1]
+include::choose-a-single-registry-or-multiple-registries.adoc[leveloffset=+1,navtitle="Single or multiple registries"]
 
 // Job: Size and subscribe to Red Hat Quay
-include::size-and-subscribe-to-red-hat-quay.adoc[leveloffset=+1]
+include::size-and-subscribe-to-red-hat-quay.adoc[leveloffset=+1,navtitle="Size and subscribe"]
 
 // Job: Plan a deployment topology
 include::plan-a-deployment-topology.adoc[leveloffset=+1]
@@ -21,21 +21,21 @@ include::plan-a-deployment-topology.adoc[leveloffset=+1]
 include::choose-a-quay-io-plan.adoc[leveloffset=+1]
 
 // Job: Plan a proof of concept Quay deployment
-include::plan-a-proof-of-concept-quay-deployment.adoc[leveloffset=+1]
+include::plan-a-proof-of-concept-quay-deployment.adoc[leveloffset=+1,navtitle="Proof of concept deployment"]
 
 // Job: Plan a Red Hat Quay on OpenShift Container Platform
-include::plan-a-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1]
+include::plan-a-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1,navtitle="{ocp} deployment"]
 
 // Job: Plan a high availability Quay deployment
-include::plan-a-high-availability-quay-deployment.adoc[leveloffset=+1]
+include::plan-a-high-availability-quay-deployment.adoc[leveloffset=+1,navtitle="High availability deployment"]
 
 // Job: Plan a public cloud deployment
-include::plan-a-public-cloud-deployment.adoc[leveloffset=+1]
+include::plan-a-public-cloud-deployment.adoc[leveloffset=+1,navtitle="Public cloud deployment"]
 
 // Content distribution (decision + architecture)
 // Job: Plan content distribution and geo-replication
-include::plan-content-distribution-and-geo-replication.adoc[leveloffset=+1]
+include::plan-content-distribution-and-geo-replication.adoc[leveloffset=+1,navtitle="Content distribution"]
 
 // Optional capability planning
 // Job: Plan container image builds with Red Hat Quay
-include::plan-container-image-builds-with-red-hat-quay.adoc[leveloffset=+1]
+include::plan-container-image-builds-with-red-hat-quay.adoc[leveloffset=+1,navtitle="Container image builds"]

--- a/quay_jtbd/secure/add-trusted-certificate-authorities.adoc
+++ b/quay_jtbd/secure/add-trusted-certificate-authorities.adoc
@@ -5,7 +5,7 @@
 :context: add_trusted_certificate_authorities
 
 [role="_abstract"]
-Add trusted certificate authorities for LDAP, storage, and other TLS endpoints on standalone, container, and OpenShift deployments.
+Add trusted certificate authorities for LDAP, storage, and other TLS endpoints on standalone, container, and {ocp} deployments.
 
 include::modules/config-extra-ca-certs-quay.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Plan and Discover category MAP includes for jobs with long page titles. Full assembly titles are unchanged.

### Plan

| Page title | LHS navtitle |
|------------|--------------|
| Plan supporting infrastructure for Red Hat Quay | Supporting infrastructure |
| Choose a single registry or multiple registries | Single or multiple registries |
| Size and subscribe to Red Hat Quay | Size and subscribe |
| Plan a proof of concept deployment | Proof of concept deployment |
| Plan a {productname} deployment on {ocp} | OpenShift deployment |
| Plan a high availability deployment | High availability deployment |
| Plan a public cloud deployment | Public cloud deployment |
| Plan content distribution and geo-replication | Content distribution |
| Plan container image builds with Red Hat Quay | Container image builds |

Left unchanged: **Plan a deployment topology**, **Choose a Quay.io plan** (already short).

### Discover

| Page title | LHS navtitle |
|------------|--------------|
| Understand Red Hat Quay capabilities and architecture | Capabilities and architecture |
| Understand Red Hat Quay infrastructure and governance | Infrastructure and governance |
| Evaluate Quay.io as a hosted registry option | Evaluate Quay.io |
| Understand Red Hat Quay's tenancy model | Tenancy model |
| Understand the Red Hat Quay permissions model | Permissions model |

Left unchanged: **Understand Clair vulnerability scanning**, **Understand the Quay Bridge Operator** (already short).

Reference category intentionally omitted per author request.

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Plan and Discover in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)