### PR TITLE
Add Get started and Upgrade job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/get_started/master.adoc
+++ b/quay_jtbd/get_started/master.adoc
@@ -8,10 +8,10 @@ include::_attributes/attributes.adoc[]
 include::get-started-with-quay-io.adoc[leveloffset=+1]
 
 // Job: Get started after deploying Quay on OpenShift Container Platform
-include::get-started-after-deploying-quay-on-openshift-container-platform.adoc[leveloffset=+1]
+include::get-started-after-deploying-quay-on-openshift-container-platform.adoc[leveloffset=+1,navtitle="After {ocp} deployment"]
 
 // Job: Get started after deploying Quay on standalone hosts
-include::get-started-after-deploying-quay-on-standalone-hosts.adoc[leveloffset=+1]
+include::get-started-after-deploying-quay-on-standalone-hosts.adoc[leveloffset=+1,navtitle="After standalone deployment"]
 
 // Shared first-success tasks
 // Job: Create your first organization
@@ -27,4 +27,4 @@ include::push-and-pull-your-first-image.adoc[leveloffset=+1]
 include::view-your-first-clair-scan.adoc[leveloffset=+1]
 
 // Job: Enable and make your first Quay API call
-include::enable-and-make-your-first-quay-api-call.adoc[leveloffset=+1]
+include::enable-and-make-your-first-quay-api-call.adoc[leveloffset=+1,navtitle="First API call"]

--- a/quay_jtbd/upgrade/master.adoc
+++ b/quay_jtbd/upgrade/master.adoc
@@ -4,22 +4,22 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Get Red Hat Quay release notifications
-include::get-red-hat-quay-release-notifications.adoc[leveloffset=+1]
+include::get-red-hat-quay-release-notifications.adoc[leveloffset=+1,navtitle="Release notifications"]
 
 // Job: Upgrade {productname-ocp} Container Platform
-include::upgrade-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1]
+include::upgrade-red-hat-quay-on-openshift-container-platform.adoc[leveloffset=+1,navtitle="Upgrade on {ocp}"]
 
 // Job: Upgrade a standalone Red Hat Quay deployment
-include::upgrade-a-standalone-red-hat-quay-deployment.adoc[leveloffset=+1]
+include::upgrade-a-standalone-red-hat-quay-deployment.adoc[leveloffset=+1,navtitle="Standalone deployment"]
 
 // Job: Upgrade a geo-replicated Red Hat Quay deployment
-include::upgrade-a-geo-replicated-red-hat-quay-deployment.adoc[leveloffset=+1]
+include::upgrade-a-geo-replicated-red-hat-quay-deployment.adoc[leveloffset=+1,navtitle="Geo-replicated deployment"]
 
 // Job: Upgrade the Quay Bridge Operator
 include::upgrade-the-quay-bridge-operator.adoc[leveloffset=+1]
 
 // Job: Upgrade the Clair PostgreSQL database
-include::upgrade-the-clair-postgresql-database.adoc[leveloffset=+1]
+include::upgrade-the-clair-postgresql-database.adoc[leveloffset=+1,navtitle="Clair PostgreSQL database"]
 
 // Job: Downgrade or roll back Red Hat Quay
-include::downgrade-or-roll-back-red-hat-quay.adoc[leveloffset=+1]
+include::downgrade-or-roll-back-red-hat-quay.adoc[leveloffset=+1,navtitle="Downgrade or roll back"]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Get started and Upgrade category MAP includes for jobs with long page titles. Full assembly titles are unchanged.

### Get started

| Page title | LHS navtitle |
|------------|--------------|
| Get started after deploying Quay on OpenShift Container Platform | After {ocp} deployment |
| Get started after deploying {productname} on standalone hosts | After standalone deployment |
| Enable and make your first Quay API call | First API call |

Left unchanged: **Get started with Quay.io**, **Create your first organization**, **Create your first repository**, **Push and pull your first image**, **View your first Clair scan** (already short).

### Upgrade

| Page title | LHS navtitle |
|------------|--------------|
| Get Red Hat Quay release notifications | Release notifications |
| Upgrade {productname-ocp} Container Platform | Upgrade on {ocp} |
| Upgrade a standalone Red Hat Quay deployment | Standalone deployment |
| Upgrade a geo-replicated Red Hat Quay deployment | Geo-replicated deployment |
| Upgrade the Clair PostgreSQL database | Clair PostgreSQL database |
| Downgrade or roll back Red Hat Quay | Downgrade or roll back |

Left unchanged: **Upgrade the Quay Bridge Operator** (already short).

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Get started and Upgrade in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)