### PR TITLE
Add Migrate job navtitles for LHS navigation

### DIFF
--- a/quay_jtbd/migrate/master.adoc
+++ b/quay_jtbd/migrate/master.adoc
@@ -4,10 +4,10 @@ include::_attributes/attributes.adoc[]
 
 
 // Job: Migrate a QuayEcosystem deployment to QuayRegistry
-include::migrate-a-quayecosystem-deployment-to-quayregistry.adoc[leveloffset=+1]
+include::migrate-a-quayecosystem-deployment-to-quayregistry.adoc[leveloffset=+1,navtitle="QuayEcosystem to QuayRegistry"]
 
 // Job: Migrate a standalone Red Hat Quay deployment to the Operator
-include::migrate-a-standalone-red-hat-quay-deployment-to-the-operator.adoc[leveloffset=+1]
+include::migrate-a-standalone-red-hat-quay-deployment-to-the-operator.adoc[leveloffset=+1,navtitle="Standalone to Operator"]
 
 // Job: Migrate Microsoft Entra ID OIDC from v1.0 to v2.0
-include::migrate-microsoft-entra-id-oidc-from-v1-0-to-v2-0.adoc[leveloffset=+1]
+include::migrate-microsoft-entra-id-oidc-from-v1-0-to-v2-0.adoc[leveloffset=+1,navtitle="Entra ID OIDC v1 to v2"]


### PR DESCRIPTION
## Summary
Add `navtitle="..."` on Migrate category MAP includes for jobs with long page titles. Full assembly titles are unchanged.

### Migrate

| Page title | LHS navtitle |
|------------|--------------|
| Migrate a QuayEcosystem deployment to QuayRegistry | QuayEcosystem to QuayRegistry |
| Migrate a standalone Red Hat Quay deployment to the Operator | Standalone to Operator |
| Migrate Microsoft Entra ID OIDC from v1.0 to v2.0 | Entra ID OIDC v1 to v2 |

### What's new

No changes — **Red Hat Quay Release Notes** is already short enough for LHS navigation.

## Test plan
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Migrate in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)