### PR TITLE
fix(quay-docs):Adding changes to quaydocumentationfixPROJQUAY-12811 branch

### DIFF
--- a/modules/config-fields-quota-management.adoc
+++ b/modules/config-fields-quota-management.adoc
@@ -29,7 +29,7 @@ The following configuration fields enable and customize quota management functio
 
 **Default:** `300`
 
-| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | String | Enables system default quota reject byte allowance for all organizations. 
+| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | Integer | Enables system default quota reject byte allowance for all organizations.
 
 By default, no limit is set.
 
@@ -56,7 +56,7 @@ By default, no limit is set.
 # ...
 FEATURE_QUOTA_MANAGEMENT: true
 FEATURE_QUOTA_NOTIFICATIONS: true
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: "100gb"
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 QUOTA_BACKFILL: true
 QUOTA_TOTAL_DELAY_SECONDS: 3600
 QUOTA_NOTIFICATION_COOLDOWN_SECONDS: 86400

--- a/modules/setting-default-quota.adoc
+++ b/modules/setting-default-quota.adoc
@@ -16,7 +16,7 @@ The following procedure shows you how to configure a system-wide default quota.
 [source,yaml]
 ----
 # ...
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 100gb
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 # ...
 ----
 


### PR DESCRIPTION
Issue:
After enabling the default quota (`DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: "20gb"`) for all Quay organizations, the customer encountered a “writing manifest” error when pushing images.

When they remove this configuration from config.yaml then they were able to push an images successfully.

[Resolution]

I observed in the Quay project codebase that the `DEFAULT_SYSTEM_REJECT_QUOTA_BYTES` configuration is defined as an integer, whereas the customer was providing its value as a string (based on this doc: https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/red-hat-quay-quota-management-and-enforcement#default-quota).

I changed the current field `DEFAULT_SYSTEM_REJECT_QUOTA_BYTES` value to integer.