### PR TITLE
Fix Plan chunked jobs with missing module includes

### DIFF
--- a/modules/billing-information.adoc
+++ b/modules/billing-information.adoc
@@ -1,5 +1,6 @@
-// module included in the following assemblies:
-
+// Module included in the following assemblies:
+//
+// * quay_jtbd/plan/choose-a-quay-io-plan.adoc
 // * quay_io/master.adoc
 
 :_mod-docs-content-type: CONCEPT

--- a/quay_jtbd/plan/choose-a-quay-io-plan.adoc
+++ b/quay_jtbd/plan/choose-a-quay-io-plan.adoc
@@ -8,3 +8,7 @@
 Compare Quay.io plan tiers and features to select the hosted registry option that fits your organization.
 
 include::modules/quayio-pricing-overview.adoc[leveloffset=+1]
+
+include::modules/pricing-page-quayio.adoc[leveloffset=+2,toc="no"]
+
+include::modules/billing-information.adoc[leveloffset=+2,toc="no"]

--- a/quay_jtbd/plan/plan-a-high-availability-quay-deployment.adoc
+++ b/quay_jtbd/plan/plan-a-high-availability-quay-deployment.adoc
@@ -9,4 +9,4 @@ Before you install a highly available registry, review shared infrastructure req
 
 include::modules/con_quay_ha_plan_requirements.adoc[leveloffset=+1]
 
-include::modules/con_quay_ha_plan_capacity.adoc[leveloffset=+1]
+include::modules/con_quay_ha_plan_capacity.adoc[leveloffset=+2,toc="no"]


### PR DESCRIPTION
## Summary
Fixes the two Plan job assemblies flagged by `map-check` as invalid chunked pages (`:chunk-to-content:` with no resolvable child includes when referenced modules are absent).

- **Choose a Quay.io plan** — add `pricing-page-quayio` and `billing-information` modules (the pricing procedure module already listed this assembly in its header but was not included).
- **Plan a high availability deployment** — keep both HA planning modules; nest capacity under requirements with `leveloffset=+2,toc="no"` for RHS-only display.
- **billing-information** — add assembly cross-reference for the Plan job.

## Test plan
- [ ] `map-check` reports no `invalid chunk` errors for Plan jobs (with `maps/navigation.adoc` symlink to `quay-3-18-navigation.adoc`)
- [ ] `./build_docs_preview` completes without errors
- [ ] Spot-check Plan jobs in `/quay-3-18-navigation.html`


Made with [Cursor](https://cursor.com)