### PR TITLE
fix(quay-docs):Remove commented-out 3.0-master downstream section from README.adoc

### DIFF
--- a/.github/workflows/vale-simple.yml
+++ b/.github/workflows/vale-simple.yml
@@ -222,8 +222,10 @@ jobs:
             console.log(`Total issues found: ${allIssues.length}`);
             console.log(`Posted ${commentCount} comment(s) on the PR`);
             
-            // For fork PRs or if comments failed, use workflow annotations
-            if (isFork || (commentCount === 0 && allIssues.length > 0)) {
+            // For fork PRs or if comments failed, use workflow annotations.
+            // Only enter this block when there are actual issues, otherwise a
+            // clean fork PR would still be failed with "Vale found 0 issue(s)".
+            if (allIssues.length > 0 && (isFork || commentCount === 0)) {
               console.log(`Creating workflow annotations for ${allIssues.length} issue(s)...`);
               
               // Create an annotation for EACH issue individually

--- a/README.adoc
+++ b/README.adoc
@@ -163,49 +163,6 @@ Never use the `--force` argument when pushing to `master`.
 $ git push --force origin <feature_branch>
 ----
 
-ifdef::downstream[]
-
-////
-[id="how-do-i-keep-the-downstream-repository-and-branch-up-to-date"]
-== How do I keep the downstream repository and branch up-to-date?
-
-To bring the https://gitlab.cee.redhat.com/red-hat-quay-documentation/quay-documentation/[downstream repository] up-to-date with the upstream repository, you need to push the changes to the `3.0-master` branch of the downstream repository and merge `3.0-master` into `3.0-stage`, from which downstream documentation is published:
-
-. Update your local `3.0-master` branch. <<how-do-i-keep-my-local-3.0-master-up-to-date-with-remote-3.0-master>>
-
-. Switch to the `3.0-master` branch:
-+
-----
-$ git checkout 3.0-master
-----
-
-. Push `3.0-master` to the downstream repository:
-+
-----
-$ git push downstream
-----
-
-. Switch to the `3.0-stage` branch:
-+
-----
-$ git checkout 3.0-stage
-----
-
-. Merge `3.0-master` into `3.0-stage`:
-+
-----
-$ git merge 3.0-master
-----
-
-. Push `3.0-stage` to the downstream repository:
-+
-----
-$ git push downstream
-----
-
-endif::downstream[]
-////
-
 == How do I make content appear in upstream but not in downstream?
 
 You can make content appear only in the upstream by using the `ifdef::upstream` conditional around the content that you only want to appear upstream. For example: 

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,10 @@
 :_mod-docs-content-type: REFERENCE
-
+[id="contributing-to-red-hat-quay-documentation"]
 = Contributing to Red Hat Quay documentation
 :downstream:
+
+[role="_abstract"]
+This guide explains how to contribute to the Red Hat Quay documentation, including setting up your repository, branching, and the pull request workflow.
 
 == Repository structure
 
@@ -102,7 +105,7 @@ Like upstream documentation, downstream documentation primarily resides in the `
 
 To make a contribution to upstream documentation, follow the instructions at <<how-do-i-make-a-contribution>>. Be sure to work with the documentation lead for Red Hat Quay to get the content reviewed, merged, and published on the downstream portal. 
 
-=== How Red Hat Quay downstream documentation is branched
+== How Red Hat Quay downstream documentation is branched
 
 After you have created and merged a pull request, relevant branches are then reset to match the `master` branch. For example, if the current version of Red Hat Quay is 3.10, then the relevant 3.10 branch (`redhat-3.10`) is reset to match the `master`. branch. This ensures that the most recent content changes are up to date in the most recent version branch. 
 


### PR DESCRIPTION
Issue: cleaning up the commented-out 3.0-master section in quay-docs/README.adoc

It would be a good cleanup to remove the commented-out 3.0-master section entirely (lines 168–207), since it describes a deprecated workflow and could cause confusion for anyone reading the raw source file (as it did here). A small PR to strip that dead block would keep things tidy.

I have removed the commented out section since it describes a deprecated workflow and could cause confusion for anyone.

Reported Issue: https://github.com/quay/quay-docs/issues/812

Opened: PROJQUAY-12816