### PR TITLE
Add map-driven LHS and RHS navigation to Surge preview

### DIFF
--- a/.github/workflows/surge-preview-deploy.yaml
+++ b/.github/workflows/surge-preview-deploy.yaml
@@ -64,7 +64,14 @@ jobs:
           // Map changed book dirs to preview paths (flat + directory).
           // Supports legacy top-level books and JTBD books under quay_jtbd/<category>/.
           const previewPaths = new Set();
+          let previewInfraChanged = false;
           for (const file of files) {
+            if (
+              file.filename === 'build_docs_preview' ||
+              file.filename.startsWith('preview/')
+            ) {
+              previewInfraChanged = true;
+            }
             if (file.filename === 'welcome.adoc' || file.filename === 'build_docs' || file.filename === 'build_docs_preview') {
               previewPaths.add('/');
               continue;
@@ -92,6 +99,24 @@ jobs:
             }
             if (fs.existsSync(path.join('dist', dirPath, 'index.html'))) {
               previewPaths.add(`/${dirPath}/`);
+            }
+          }
+
+          if (previewInfraChanged && fs.existsSync('dist/quay_jtbd')) {
+            for (const entry of fs.readdirSync('dist/quay_jtbd', { withFileTypes: true })) {
+              if (!entry.isDirectory()) continue;
+              const cat = entry.name;
+              const flat = `quay_jtbd-${cat}`;
+              if (fs.existsSync(path.join('dist', `${flat}.html`))) {
+                previewPaths.add(`/${flat}.html`);
+              }
+              if (fs.existsSync(path.join('dist', 'quay_jtbd', cat, 'index.html'))) {
+                previewPaths.add(`/quay_jtbd/${cat}/`);
+              }
+            }
+            if (fs.existsSync(path.join('dist', 'quay-3-18-navigation.html'))) {
+              previewPaths.add('/quay-3-18-navigation.html');
+              previewPaths.add('/quay_jtbd-navigation/');
             }
           }
 

--- a/build_docs_preview
+++ b/build_docs_preview
@@ -74,6 +74,12 @@ path.write_text(text)
 PY
 }
 
+inject_map_nav() {
+  local html_file="$1"
+  local master="$2"
+  python3 preview/map_nav.py "$html_file" "$master"
+}
+
 build_book() {
   local master="$1"
   local out_dir="$2"
@@ -81,14 +87,28 @@ build_book() {
   local imagesdir="$4"
   local stylesdir="$5"
   local asset_depth="${6:-1}"
+  local map_nav="${7:-}"
+  local stylesheet="${8:-redhat.css}"
 
   echo "--- ${master} -> ${out_dir} ---"
   mkdir -p "dist/${out_dir}"
-  asciidoctor "${BOOK_ATTR[@]}" -a "imagesdir=${imagesdir}" -a "stylesdir=${stylesdir}" "$master" \
+  asciidoctor "${BOOK_ATTR[@]}" -a "imagesdir=${imagesdir}" -a "stylesdir=${stylesdir}" \
+    -a "stylesheet=${stylesheet}" "$master" \
     -D "dist/${out_dir}" -o index.html
   fix_asset_paths "dist/${out_dir}/index.html" "$asset_depth"
   inject_preview_chrome "dist/${out_dir}/index.html"
+  if [[ -n "$map_nav" ]]; then
+    inject_map_nav "dist/${out_dir}/index.html" "$master"
+  fi
   cp "dist/${out_dir}/index.html" "dist/${flat_name}.html"
+}
+
+build_jtbd_category_book() {
+  local master="$1"
+  local out_dir="$2"
+  local flat_name="$3"
+  local map_nav="$4"
+  build_book "$master" "$out_dir" "$flat_name" "../../images" "../../assets/css" 2 "$map_nav"
 }
 
 BOOK_ATTR=(
@@ -136,13 +156,14 @@ if [[ -d quay_jtbd ]]; then
   for master in quay_jtbd/*/master.adoc; do
     [[ -f "$master" ]] || continue
     dir=$(basename "$(dirname "$master")")
-    build_book "$master" "quay_jtbd/${dir}" "quay_jtbd-${dir}" "../../images" "../../assets/css" 2
+    build_jtbd_category_book "$master" "quay_jtbd/${dir}" "quay_jtbd-${dir}" "1"
   done
 fi
 
 echo "=== Building JTBD product navigation MAP ==="
 if [[ -f quay-3-18-navigation.adoc ]]; then
-  build_book "quay-3-18-navigation.adoc" "quay_jtbd-navigation" "quay-3-18-navigation" "images" "assets/css" 1
+  build_book "quay-3-18-navigation.adoc" "quay_jtbd-navigation" "quay-3-18-navigation" \
+    "images" "preview/assets/css" 1 "1" "preview/assets/css/redhat.css"
 fi
 
 cp -a images dist/images

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,9 +1,8 @@
 /**
- * JTBD map preview: right-hand "On this page" nav for chunked job sections.
- * Reads #map-nav-data JSON emitted by preview/map_nav.py.
+ * JTBD map preview: chunk-scoped RHS "On this page" nav.
  *
- * Level-1 RHS entries are always visible; level-2+ children expand only when
- * their parent is clicked (accordion — one expanded section at a time).
+ * RHS switches with the top-level job (chunk) in view. Within a chunk, only the
+ * active parent section's subtree is shown; level-2+ expand as you scroll into them.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -19,21 +18,27 @@
   var rhsPanel = document.getElementById('right-toc');
   if (!rhsPanel || !data.rhsByChunk) return;
 
+  var currentChunk = null;
+  var currentRootAnchor = null;
+
   function esc(text) {
     var d = document.createElement('div');
     d.textContent = text;
     return d.innerHTML;
   }
 
-  function renderList(nodes, depth) {
+  function renderList(nodes, depth, expandRoot) {
     if (!nodes || !nodes.length) return '';
     var parts = ['<ul>'];
     nodes.forEach(function (node) {
       var hasChildren = node.children && node.children.length;
       if (hasChildren) {
-        parts.push('<li class="rhs-collapsible">');
+        var expanded = expandRoot && depth === 1 ? ' expanded' : '';
+        parts.push('<li class="rhs-collapsible' + expanded + '">');
         parts.push(
-          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="false"></button>'
+          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="' +
+            (expanded ? 'true' : 'false') +
+            '"></button>'
         );
         parts.push(
           '<a href="#' +
@@ -42,7 +47,7 @@
             esc(node.title) +
             '</a>'
         );
-        parts.push(renderList(node.children, depth + 1));
+        parts.push(renderList(node.children, depth + 1, false));
       } else {
         parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
       }
@@ -99,6 +104,45 @@
     });
   }
 
+  function collectAnchors(node, out) {
+    if (!node) return;
+    out.push(node.anchor);
+    (node.children || []).forEach(function (child) {
+      collectAnchors(child, out);
+    });
+  }
+
+  function findRootForAnchor(roots, anchor) {
+    for (var i = 0; i < roots.length; i++) {
+      var anchors = [];
+      collectAnchors(roots[i], anchors);
+      if (anchors.indexOf(anchor) !== -1) return roots[i];
+    }
+    return null;
+  }
+
+  function activeRhsRootInChunk(chunkAnchor) {
+    var roots = data.rhsByChunk[chunkAnchor];
+    if (!roots || !roots.length) return null;
+
+    var bestRoot = null;
+    var bestTop = -Infinity;
+    roots.forEach(function (root) {
+      var anchors = [];
+      collectAnchors(root, anchors);
+      anchors.forEach(function (anchor) {
+        var el = document.getElementById(anchor);
+        if (!el) return;
+        var top = el.getBoundingClientRect().top;
+        if (top <= 120 && top > bestTop) {
+          bestTop = top;
+          bestRoot = root;
+        }
+      });
+    });
+    return bestRoot || roots[0];
+  }
+
   function expandParentForAnchor(anchor) {
     if (!anchor) return;
     var link = rhsPanel.querySelector('a[href="#' + CSS.escape(anchor) + '"]');
@@ -107,25 +151,16 @@
     if (li) expandRhsItem(li);
   }
 
-  function expandRhsParentForAnchor(anchor) {
-    if (!anchor) return;
-    var selector = 'a.rhs-parent[href="#' + anchor.replace(/"/g, '\\"') + '"]';
-    var parentLink = rhsPanel.querySelector(selector);
-    if (!parentLink) return;
-    var li = parentLink.closest('li.rhs-collapsible');
-    if (li) expandRhsItem(li);
-  }
-
-  function renderRhs(chunkAnchor) {
-    var nodes = data.rhsByChunk[chunkAnchor];
-    if (!nodes || !nodes.length) {
+  function renderRhs(chunkAnchor, rootNode) {
+    if (!rootNode) {
       rhsPanel.innerHTML =
         '<div class="right-toc-title">On this page</div>' +
         '<p class="right-toc-empty">No nested sections</p>';
       return;
     }
     rhsPanel.innerHTML =
-      '<div class="right-toc-title">On this page</div>' + renderList(nodes, 1);
+      '<div class="right-toc-title">On this page</div>' +
+      renderList([rootNode], 1, true);
     bindRhsCollapse();
     bindRhsScrollSpy();
   }
@@ -155,9 +190,7 @@
         l.classList.toggle('active', l === active);
       });
       if (active) {
-        var activeAnchor = active.getAttribute('href').slice(1);
-        expandParentForAnchor(activeAnchor);
-        expandRhsParentForAnchor(activeAnchor);
+        expandParentForAnchor(active.getAttribute('href').slice(1));
       }
     }
 
@@ -186,25 +219,41 @@
         best = anchor;
       }
     });
-    return best || (data.chunkAnchors && data.chunkAnchors[0]);
+    return best;
+  }
+
+  function syncRhsFromScroll() {
+    var chunk = activeChunkFromScroll();
+    if (!chunk || !data.rhsByChunk[chunk]) {
+      if (currentChunk !== null) {
+        rhsPanel.innerHTML =
+          '<div class="right-toc-title">On this page</div>' +
+          '<p class="right-toc-empty">Scroll to a section</p>';
+        currentChunk = null;
+        currentRootAnchor = null;
+      }
+      return;
+    }
+
+    var root = activeRhsRootInChunk(chunk);
+    var rootAnchor = root ? root.anchor : null;
+    if (chunk === currentChunk && rootAnchor === currentRootAnchor) {
+      bindRhsScrollSpy();
+      return;
+    }
+
+    currentChunk = chunk;
+    currentRootAnchor = rootAnchor;
+    renderRhs(chunk, root);
   }
 
   markChunkSections();
-  var current = activeChunkFromScroll();
-  if (current) renderRhs(current);
+  syncRhsFromScroll();
 
   var scrollTimer;
   window.addEventListener('scroll', function () {
     clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(function () {
-      var next = activeChunkFromScroll();
-      if (next && next !== current) {
-        current = next;
-        renderRhs(current);
-      } else {
-        bindRhsScrollSpy();
-      }
-    }, 80);
+    scrollTimer = setTimeout(syncRhsFromScroll, 80);
   });
 
   document.getElementById('toc').addEventListener('click', function (e) {
@@ -212,14 +261,19 @@
     if (!a) return;
     var id = a.getAttribute('href').slice(1);
     if (data.rhsByChunk[id]) {
-      current = id;
-      setTimeout(function () {
-        renderRhs(id);
-      }, 50);
+      currentChunk = id;
+      currentRootAnchor = null;
+      setTimeout(syncRhsFromScroll, 50);
       return;
     }
     setTimeout(function () {
-      expandRhsParentForAnchor(id);
+      if (!currentChunk) return;
+      var roots = data.rhsByChunk[currentChunk];
+      var root = findRootForAnchor(roots, id);
+      if (root) {
+        currentRootAnchor = root.anchor;
+        renderRhs(currentChunk, root);
+      }
     }, 50);
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,6 +1,9 @@
 /**
- * JTBD map preview: scroll-driven RHS "On this page" nav.
- * Shows only == subsections for the content section currently in view.
+ * JTBD map preview: right-hand "On this page" nav for chunked job sections.
+ * Reads #map-nav-data JSON emitted by preview/map_nav.py.
+ *
+ * Level-1 RHS entries are always visible; level-2+ children expand only when
+ * their parent is clicked (accordion — one expanded section at a time).
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -14,10 +17,7 @@
   }
 
   var rhsPanel = document.getElementById('right-toc');
-  if (!rhsPanel || !data.rhsSectionsByChunk) return;
-
-  var currentChunk = null;
-  var currentSectionAnchor = null;
+  if (!rhsPanel || !data.rhsByChunk) return;
 
   function esc(text) {
     var d = document.createElement('div');
@@ -25,82 +25,109 @@
     return d.innerHTML;
   }
 
-  function renderFlatList(children) {
-    if (!children || !children.length) return '';
-    var parts = ['<ul class="rhs-list">'];
-    children.forEach(function (node) {
-      parts.push(
-        '<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a></li>'
-      );
+  function renderList(nodes, depth) {
+    if (!nodes || !nodes.length) return '';
+    var parts = ['<ul>'];
+    nodes.forEach(function (node) {
+      var hasChildren = node.children && node.children.length;
+      if (hasChildren) {
+        parts.push('<li class="rhs-collapsible">');
+        parts.push(
+          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="false"></button>'
+        );
+        parts.push(
+          '<a href="#' +
+            esc(node.anchor) +
+            '" class="rhs-parent">' +
+            esc(node.title) +
+            '</a>'
+        );
+        parts.push(renderList(node.children, depth + 1));
+      } else {
+        parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
+      }
+      parts.push('</li>');
     });
     parts.push('</ul>');
     return parts.join('');
   }
 
-  function renderRhsSection(section) {
-    var title = '<div class="right-toc-title">On this page</div>';
-    if (!section || !section.children || !section.children.length) {
-      rhsPanel.innerHTML = title + '<p class="right-toc-empty">No subsections</p>';
-      bindRhsScrollSpy();
+  function collapseRhsItem(li) {
+    li.classList.remove('expanded');
+    var btn = li.querySelector('.rhs-chevron');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+
+  function expandRhsItem(li) {
+    var parentUl = li.parentElement;
+    if (parentUl) {
+      parentUl.querySelectorAll(':scope > li.rhs-collapsible.expanded').forEach(function (other) {
+        if (other !== li) collapseRhsItem(other);
+      });
+    }
+    li.classList.add('expanded');
+    var btn = li.querySelector('.rhs-chevron');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'true');
+      btn.setAttribute('aria-label', 'Hide subsections');
+    }
+  }
+
+  function toggleRhsItem(li) {
+    if (li.classList.contains('expanded')) {
+      collapseRhsItem(li);
+    } else {
+      expandRhsItem(li);
+    }
+  }
+
+  function bindRhsCollapse() {
+    rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
+      var btn = li.querySelector('.rhs-chevron');
+      var link = li.querySelector('a.rhs-parent');
+      if (btn) {
+        btn.addEventListener('click', function (e) {
+          e.preventDefault();
+          toggleRhsItem(li);
+        });
+      }
+      if (link) {
+        link.addEventListener('click', function () {
+          expandRhsItem(li);
+        });
+      }
+    });
+  }
+
+  function expandParentForAnchor(anchor) {
+    if (!anchor) return;
+    var link = rhsPanel.querySelector('a[href="#' + CSS.escape(anchor) + '"]');
+    if (!link) return;
+    var li = link.closest('li.rhs-collapsible');
+    if (li) expandRhsItem(li);
+  }
+
+  function expandRhsParentForAnchor(anchor) {
+    if (!anchor) return;
+    var selector = 'a.rhs-parent[href="#' + anchor.replace(/"/g, '\\"') + '"]';
+    var parentLink = rhsPanel.querySelector(selector);
+    if (!parentLink) return;
+    var li = parentLink.closest('li.rhs-collapsible');
+    if (li) expandRhsItem(li);
+  }
+
+  function renderRhs(chunkAnchor) {
+    var nodes = data.rhsByChunk[chunkAnchor];
+    if (!nodes || !nodes.length) {
+      rhsPanel.innerHTML =
+        '<div class="right-toc-title">On this page</div>' +
+        '<p class="right-toc-empty">No nested sections</p>';
       return;
     }
-    rhsPanel.innerHTML = title + renderFlatList(section.children);
+    rhsPanel.innerHTML =
+      '<div class="right-toc-title">On this page</div>' + renderList(nodes, 1);
+    bindRhsCollapse();
     bindRhsScrollSpy();
-  }
-
-  function activeChunkFromScroll() {
-    var best = null;
-    var bestTop = -Infinity;
-    (data.chunkAnchors || []).forEach(function (anchor) {
-      var el = document.getElementById(anchor);
-      if (!el) return;
-      var top = el.getBoundingClientRect().top;
-      if (top <= 120 && top > bestTop) {
-        bestTop = top;
-        best = anchor;
-      }
-    });
-    return best;
-  }
-
-  function activeSectionInChunk(chunkAnchor) {
-    var sections = data.rhsSectionsByChunk[chunkAnchor];
-    if (!sections || !sections.length) return null;
-    var best = null;
-    var bestTop = -Infinity;
-    sections.forEach(function (section) {
-      var el = document.getElementById(section.anchor);
-      if (!el) return;
-      var top = el.getBoundingClientRect().top;
-      if (top <= 120 && top > bestTop) {
-        bestTop = top;
-        best = section;
-      }
-    });
-    return best;
-  }
-
-  function syncRhsFromScroll() {
-    var chunk = activeChunkFromScroll();
-    if (!chunk) {
-      if (currentChunk !== null) {
-        rhsPanel.innerHTML =
-          '<div class="right-toc-title">On this page</div>' +
-          '<p class="right-toc-empty">Scroll to a section</p>';
-        currentChunk = null;
-        currentSectionAnchor = null;
-      }
-      return;
-    }
-    var section = activeSectionInChunk(chunk);
-    var sectionAnchor = section ? section.anchor : null;
-    if (chunk === currentChunk && sectionAnchor === currentSectionAnchor) {
-      bindRhsScrollSpy();
-      return;
-    }
-    currentChunk = chunk;
-    currentSectionAnchor = sectionAnchor;
-    renderRhsSection(section);
   }
 
   function bindRhsScrollSpy() {
@@ -127,6 +154,11 @@
       links.forEach(function (l) {
         l.classList.toggle('active', l === active);
       });
+      if (active) {
+        var activeAnchor = active.getAttribute('href').slice(1);
+        expandParentForAnchor(activeAnchor);
+        expandRhsParentForAnchor(activeAnchor);
+      }
     }
 
     $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
@@ -142,12 +174,52 @@
     });
   }
 
+  function activeChunkFromScroll() {
+    var best = null;
+    var bestTop = -Infinity;
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var el = document.getElementById(anchor);
+      if (!el) return;
+      var top = el.getBoundingClientRect().top;
+      if (top <= 120 && top > bestTop) {
+        bestTop = top;
+        best = anchor;
+      }
+    });
+    return best || (data.chunkAnchors && data.chunkAnchors[0]);
+  }
+
   markChunkSections();
-  syncRhsFromScroll();
+  var current = activeChunkFromScroll();
+  if (current) renderRhs(current);
 
   var scrollTimer;
   window.addEventListener('scroll', function () {
     clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(syncRhsFromScroll, 80);
+    scrollTimer = setTimeout(function () {
+      var next = activeChunkFromScroll();
+      if (next && next !== current) {
+        current = next;
+        renderRhs(current);
+      } else {
+        bindRhsScrollSpy();
+      }
+    }, 80);
+  });
+
+  document.getElementById('toc').addEventListener('click', function (e) {
+    var a = e.target.closest('a[href^="#"]');
+    if (!a) return;
+    var id = a.getAttribute('href').slice(1);
+    if (data.rhsByChunk[id]) {
+      current = id;
+      setTimeout(function () {
+        renderRhs(id);
+      }, 50);
+      return;
+    }
+    setTimeout(function () {
+      expandRhsParentForAnchor(id);
+    }, 50);
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,0 +1,144 @@
+/**
+ * JTBD map preview: right-hand "On this page" nav for chunked job sections.
+ * Reads #map-nav-data JSON emitted by preview/map_nav.py.
+ */
+(function () {
+  var dataEl = document.getElementById('map-nav-data');
+  if (!dataEl) return;
+
+  var data;
+  try {
+    data = JSON.parse(dataEl.textContent);
+  } catch (e) {
+    return;
+  }
+
+  var rhsPanel = document.getElementById('right-toc');
+  if (!rhsPanel || !data.rhsByChunk) return;
+
+  function esc(text) {
+    var d = document.createElement('div');
+    d.textContent = text;
+    return d.innerHTML;
+  }
+
+  function renderList(nodes, depth) {
+    if (!nodes || !nodes.length) return '';
+    var parts = ['<ul>'];
+    nodes.forEach(function (node) {
+      var cls = depth > 2 ? ' class="right-toc-too-deep"' : '';
+      parts.push('<li' + cls + '><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
+      if (node.children && node.children.length) {
+        parts.push(renderList(node.children, depth + 1));
+      }
+      parts.push('</li>');
+    });
+    parts.push('</ul>');
+    return parts.join('');
+  }
+
+  function renderRhs(chunkAnchor) {
+    var nodes = data.rhsByChunk[chunkAnchor];
+    if (!nodes || !nodes.length) {
+      rhsPanel.innerHTML =
+        '<div class="right-toc-title">On this page</div>' +
+        '<p class="right-toc-empty">No nested sections</p>';
+      return;
+    }
+    rhsPanel.innerHTML =
+      '<div class="right-toc-title">On this page</div>' + renderList(nodes, 1);
+    bindRhsScrollSpy();
+  }
+
+  function chunkForElement(el) {
+    while (el && el !== document.body) {
+      if (el.dataset && el.dataset.chunkAnchor) {
+        return el.dataset.chunkAnchor;
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  function bindRhsScrollSpy() {
+    var links = rhsPanel.querySelectorAll('a[href^="#"]');
+    if (!links.length || !window.jQuery) return;
+
+    var $ = window.jQuery;
+    var targets = [];
+    links.forEach(function (link) {
+      var id = link.getAttribute('href').slice(1);
+      var el = document.getElementById(id);
+      if (el) targets.push({ link: link, el: el });
+    });
+
+    function sync() {
+      var scrollTop = $(document).scrollTop();
+      var active = null;
+      for (var i = targets.length - 1; i >= 0; i--) {
+        if (scrollTop > $(targets[i].el).offset().top - 90) {
+          active = targets[i].link;
+          break;
+        }
+      }
+      links.forEach(function (l) {
+        l.classList.toggle('active', l === active);
+      });
+    }
+
+    $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
+    sync();
+  }
+
+  function markChunkSections() {
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var el = document.getElementById(anchor);
+      if (!el) return;
+      var section = el.closest('.sect1, .sect2, .sectionbody') || el.parentElement;
+      if (section) section.dataset.chunkAnchor = anchor;
+    });
+  }
+
+  function activeChunkFromScroll() {
+    var best = null;
+    var bestTop = -Infinity;
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var el = document.getElementById(anchor);
+      if (!el) return;
+      var top = el.getBoundingClientRect().top;
+      if (top <= 120 && top > bestTop) {
+        bestTop = top;
+        best = anchor;
+      }
+    });
+    return best || (data.chunkAnchors && data.chunkAnchors[0]);
+  }
+
+  markChunkSections();
+  var current = activeChunkFromScroll();
+  if (current) renderRhs(current);
+
+  var scrollTimer;
+  window.addEventListener('scroll', function () {
+    clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(function () {
+      var next = activeChunkFromScroll();
+      if (next && next !== current) {
+        current = next;
+        renderRhs(current);
+      } else {
+        bindRhsScrollSpy();
+      }
+    }, 80);
+  });
+
+  document.getElementById('toc').addEventListener('click', function (e) {
+    var a = e.target.closest('a[href^="#"]');
+    if (!a) return;
+    var id = a.getAttribute('href').slice(1);
+    if (data.rhsByChunk[id]) {
+      current = id;
+      setTimeout(function () { renderRhs(id); }, 50);
+    }
+  });
+})();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -3,7 +3,8 @@
  *
  * LHS: category MAP jobs (levels 1–2).
  * RHS: in-page detail for the active job — ==/=== subs and toc="no" modules.
- * Assembly modules already shown on the LHS are omitted; their nested content appears here instead.
+ * Assembly modules already on the LHS are omitted unless they group ==/=== subs
+ * (then kept as a collapsible parent); toc_no-only wrappers promote their children.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,9 +1,6 @@
 /**
- * JTBD map preview: right-hand "On this page" nav for chunked job sections.
- * Reads #map-nav-data JSON emitted by preview/map_nav.py.
- *
- * Level-1 RHS entries are always visible; level-2+ children expand only when
- * their parent is clicked (accordion — one expanded section at a time).
+ * JTBD map preview: scroll-driven RHS "On this page" nav.
+ * Shows only == subsections for the content section currently in view.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -17,7 +14,10 @@
   }
 
   var rhsPanel = document.getElementById('right-toc');
-  if (!rhsPanel || !data.rhsByChunk) return;
+  if (!rhsPanel || !data.rhsSectionsByChunk) return;
+
+  var currentChunk = null;
+  var currentSectionAnchor = null;
 
   function esc(text) {
     var d = document.createElement('div');
@@ -25,109 +25,82 @@
     return d.innerHTML;
   }
 
-  function renderList(nodes, depth) {
-    if (!nodes || !nodes.length) return '';
-    var parts = ['<ul>'];
-    nodes.forEach(function (node) {
-      var hasChildren = node.children && node.children.length;
-      if (hasChildren) {
-        parts.push('<li class="rhs-collapsible">');
-        parts.push(
-          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="false"></button>'
-        );
-        parts.push(
-          '<a href="#' +
-            esc(node.anchor) +
-            '" class="rhs-parent">' +
-            esc(node.title) +
-            '</a>'
-        );
-        parts.push(renderList(node.children, depth + 1));
-      } else {
-        parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
-      }
-      parts.push('</li>');
+  function renderFlatList(children) {
+    if (!children || !children.length) return '';
+    var parts = ['<ul class="rhs-list">'];
+    children.forEach(function (node) {
+      parts.push(
+        '<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a></li>'
+      );
     });
     parts.push('</ul>');
     return parts.join('');
   }
 
-  function collapseRhsItem(li) {
-    li.classList.remove('expanded');
-    var btn = li.querySelector('.rhs-chevron');
-    if (btn) btn.setAttribute('aria-expanded', 'false');
-  }
-
-  function expandRhsItem(li) {
-    var parentUl = li.parentElement;
-    if (parentUl) {
-      parentUl.querySelectorAll(':scope > li.rhs-collapsible.expanded').forEach(function (other) {
-        if (other !== li) collapseRhsItem(other);
-      });
-    }
-    li.classList.add('expanded');
-    var btn = li.querySelector('.rhs-chevron');
-    if (btn) {
-      btn.setAttribute('aria-expanded', 'true');
-      btn.setAttribute('aria-label', 'Hide subsections');
-    }
-  }
-
-  function toggleRhsItem(li) {
-    if (li.classList.contains('expanded')) {
-      collapseRhsItem(li);
-    } else {
-      expandRhsItem(li);
-    }
-  }
-
-  function bindRhsCollapse() {
-    rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
-      var btn = li.querySelector('.rhs-chevron');
-      var link = li.querySelector('a.rhs-parent');
-      if (btn) {
-        btn.addEventListener('click', function (e) {
-          e.preventDefault();
-          toggleRhsItem(li);
-        });
-      }
-      if (link) {
-        link.addEventListener('click', function () {
-          expandRhsItem(li);
-        });
-      }
-    });
-  }
-
-  function expandParentForAnchor(anchor) {
-    if (!anchor) return;
-    var link = rhsPanel.querySelector('a[href="#' + CSS.escape(anchor) + '"]');
-    if (!link) return;
-    var li = link.closest('li.rhs-collapsible');
-    if (li) expandRhsItem(li);
-  }
-
-  function expandRhsParentForAnchor(anchor) {
-    if (!anchor) return;
-    var selector = 'a.rhs-parent[href="#' + anchor.replace(/"/g, '\\"') + '"]';
-    var parentLink = rhsPanel.querySelector(selector);
-    if (!parentLink) return;
-    var li = parentLink.closest('li.rhs-collapsible');
-    if (li) expandRhsItem(li);
-  }
-
-  function renderRhs(chunkAnchor) {
-    var nodes = data.rhsByChunk[chunkAnchor];
-    if (!nodes || !nodes.length) {
-      rhsPanel.innerHTML =
-        '<div class="right-toc-title">On this page</div>' +
-        '<p class="right-toc-empty">No nested sections</p>';
+  function renderRhsSection(section) {
+    var title = '<div class="right-toc-title">On this page</div>';
+    if (!section || !section.children || !section.children.length) {
+      rhsPanel.innerHTML = title + '<p class="right-toc-empty">No subsections</p>';
+      bindRhsScrollSpy();
       return;
     }
-    rhsPanel.innerHTML =
-      '<div class="right-toc-title">On this page</div>' + renderList(nodes, 1);
-    bindRhsCollapse();
+    rhsPanel.innerHTML = title + renderFlatList(section.children);
     bindRhsScrollSpy();
+  }
+
+  function activeChunkFromScroll() {
+    var best = null;
+    var bestTop = -Infinity;
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var el = document.getElementById(anchor);
+      if (!el) return;
+      var top = el.getBoundingClientRect().top;
+      if (top <= 120 && top > bestTop) {
+        bestTop = top;
+        best = anchor;
+      }
+    });
+    return best;
+  }
+
+  function activeSectionInChunk(chunkAnchor) {
+    var sections = data.rhsSectionsByChunk[chunkAnchor];
+    if (!sections || !sections.length) return null;
+    var best = null;
+    var bestTop = -Infinity;
+    sections.forEach(function (section) {
+      var el = document.getElementById(section.anchor);
+      if (!el) return;
+      var top = el.getBoundingClientRect().top;
+      if (top <= 120 && top > bestTop) {
+        bestTop = top;
+        best = section;
+      }
+    });
+    return best;
+  }
+
+  function syncRhsFromScroll() {
+    var chunk = activeChunkFromScroll();
+    if (!chunk) {
+      if (currentChunk !== null) {
+        rhsPanel.innerHTML =
+          '<div class="right-toc-title">On this page</div>' +
+          '<p class="right-toc-empty">Scroll to a section</p>';
+        currentChunk = null;
+        currentSectionAnchor = null;
+      }
+      return;
+    }
+    var section = activeSectionInChunk(chunk);
+    var sectionAnchor = section ? section.anchor : null;
+    if (chunk === currentChunk && sectionAnchor === currentSectionAnchor) {
+      bindRhsScrollSpy();
+      return;
+    }
+    currentChunk = chunk;
+    currentSectionAnchor = sectionAnchor;
+    renderRhsSection(section);
   }
 
   function bindRhsScrollSpy() {
@@ -154,11 +127,6 @@
       links.forEach(function (l) {
         l.classList.toggle('active', l === active);
       });
-      if (active) {
-        var activeAnchor = active.getAttribute('href').slice(1);
-        expandParentForAnchor(activeAnchor);
-        expandRhsParentForAnchor(activeAnchor);
-      }
     }
 
     $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
@@ -174,52 +142,12 @@
     });
   }
 
-  function activeChunkFromScroll() {
-    var best = null;
-    var bestTop = -Infinity;
-    (data.chunkAnchors || []).forEach(function (anchor) {
-      var el = document.getElementById(anchor);
-      if (!el) return;
-      var top = el.getBoundingClientRect().top;
-      if (top <= 120 && top > bestTop) {
-        bestTop = top;
-        best = anchor;
-      }
-    });
-    return best || (data.chunkAnchors && data.chunkAnchors[0]);
-  }
-
   markChunkSections();
-  var current = activeChunkFromScroll();
-  if (current) renderRhs(current);
+  syncRhsFromScroll();
 
   var scrollTimer;
   window.addEventListener('scroll', function () {
     clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(function () {
-      var next = activeChunkFromScroll();
-      if (next && next !== current) {
-        current = next;
-        renderRhs(current);
-      } else {
-        bindRhsScrollSpy();
-      }
-    }, 80);
-  });
-
-  document.getElementById('toc').addEventListener('click', function (e) {
-    var a = e.target.closest('a[href^="#"]');
-    if (!a) return;
-    var id = a.getAttribute('href').slice(1);
-    if (data.rhsByChunk[id]) {
-      current = id;
-      setTimeout(function () {
-        renderRhs(id);
-      }, 50);
-      return;
-    }
-    setTimeout(function () {
-      expandRhsParentForAnchor(id);
-    }, 50);
+    scrollTimer = setTimeout(syncRhsFromScroll, 80);
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -2,8 +2,8 @@
  * JTBD Surge preview: map-preview style RHS ("On this page").
  *
  * LHS: category MAP jobs (levels 1–2).
- * RHS: assembly L1 modules for the active job — always listed, collapsible.
- * L2 modules and ==/=== subsections appear only when their L1 row is expanded.
+ * RHS: in-page detail for the active job — ==/=== subs and toc="no" modules.
+ * Assembly modules already shown on the LHS are omitted; their nested content appears here instead.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -21,7 +21,7 @@
 
   var SCROLL_LINE = 120;
   var currentChunk = null;
-  var expandedL1ByChunk = {};
+  var expandedByChunk = {};
 
   function esc(text) {
     var d = document.createElement('div');
@@ -35,19 +35,53 @@
     return el.getBoundingClientRect().top;
   }
 
-  function renderChildTree(nodes) {
+  function expandedSet(chunk) {
+    if (!expandedByChunk[chunk]) expandedByChunk[chunk] = new Set();
+    return expandedByChunk[chunk];
+  }
+
+  function isExpanded(chunk, anchor) {
+    return expandedSet(chunk).has(anchor);
+  }
+
+  function renderNavNode(node, chunk) {
+    var hasChildren = node.children && node.children.length;
+    if (!hasChildren) {
+      return '<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a></li>';
+    }
+
+    var expanded = isExpanded(chunk, node.anchor);
+    var parts = ['<li class="rhs-collapsible' + (expanded ? ' expanded' : '') + '">'];
+    parts.push(
+      '<button type="button" class="rhs-chevron" aria-label="' +
+        (expanded ? 'Collapse section' : 'Expand section') +
+        '" aria-expanded="' +
+        (expanded ? 'true' : 'false') +
+        '"></button>'
+    );
+    parts.push(
+      '<a href="#' +
+        esc(node.anchor) +
+        '" class="rhs-parent">' +
+        esc(node.title) +
+        '</a>'
+    );
+    parts.push(renderChildList(node.children, chunk));
+    parts.push('</li>');
+    return parts.join('');
+  }
+
+  function renderChildList(nodes, chunk) {
     if (!nodes || !nodes.length) return '';
     var parts = ['<ul>'];
     nodes.forEach(function (node) {
-      parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
-      parts.push(renderChildTree(node.children));
-      parts.push('</li>');
+      parts.push(renderNavNode(node, chunk));
     });
     parts.push('</ul>');
     return parts.join('');
   }
 
-  function renderChunkRhs(roots, expandedAnchor) {
+  function renderChunkRhs(roots, chunk) {
     if (!roots || !roots.length) {
       return (
         '<div class="right-toc-title">On this page</div>' +
@@ -57,57 +91,38 @@
 
     var parts = ['<div class="right-toc-title">On this page</div>', '<ul class="rhs-list">'];
     roots.forEach(function (l1) {
-      var hasChildren = l1.children && l1.children.length;
-      if (!hasChildren) {
-        parts.push('<li><a href="#' + esc(l1.anchor) + '">' + esc(l1.title) + '</a></li>');
-        return;
-      }
-
-      var expanded = expandedAnchor === l1.anchor;
-      parts.push('<li class="rhs-collapsible' + (expanded ? ' expanded' : '') + '">');
-      parts.push(
-        '<button type="button" class="rhs-chevron" aria-label="' +
-          (expanded ? 'Collapse section' : 'Expand section') +
-          '" aria-expanded="' +
-          (expanded ? 'true' : 'false') +
-          '"></button>'
-      );
-      parts.push(
-        '<a href="#' +
-          esc(l1.anchor) +
-          '" class="rhs-parent">' +
-          esc(l1.title) +
-          '</a>'
-      );
-      parts.push(renderChildTree(l1.children));
-      parts.push('</li>');
+      parts.push(renderNavNode(l1, chunk));
     });
     parts.push('</ul>');
     return parts.join('');
   }
 
-  function bindRhsCollapse(chunk, roots) {
+  function bindRhsCollapse(chunk) {
     rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
-      var link = li.querySelector('a.rhs-parent');
+      var link = li.querySelector(':scope > a.rhs-parent');
       if (!link) return;
       var anchor = link.getAttribute('href').slice(1);
 
-      function toggle() {
-        var next = expandedL1ByChunk[chunk] === anchor ? null : anchor;
-        expandedL1ByChunk[chunk] = next;
+      function toggleExpand() {
+        var set = expandedSet(chunk);
+        if (set.has(anchor)) {
+          set.delete(anchor);
+        } else {
+          set.add(anchor);
+        }
         renderChunk(chunk);
       }
 
-      var btn = li.querySelector('.rhs-chevron');
+      var btn = li.querySelector(':scope > .rhs-chevron');
       if (btn) {
         btn.addEventListener('click', function (e) {
           e.preventDefault();
-          toggle();
+          toggleExpand();
         });
       }
       link.addEventListener('click', function () {
-        if (expandedL1ByChunk[chunk] !== anchor) {
-          expandedL1ByChunk[chunk] = anchor;
+        if (!isExpanded(chunk, anchor)) {
+          expandedSet(chunk).add(anchor);
           renderChunk(chunk);
         }
       });
@@ -159,9 +174,8 @@
 
   function renderChunk(chunk) {
     var roots = data.rhsByChunk[chunk];
-    var expanded = expandedL1ByChunk[chunk] || null;
-    rhsPanel.innerHTML = renderChunkRhs(roots, expanded);
-    bindRhsCollapse(chunk, roots);
+    rhsPanel.innerHTML = renderChunkRhs(roots, chunk);
+    bindRhsCollapse(chunk);
     bindRhsScrollSpy();
   }
 

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,8 +1,9 @@
 /**
- * JTBD map preview: RHS mirrors assembly structure (L1 + nested L2/==/===).
+ * JTBD Surge preview: map-preview style RHS ("On this page").
  *
- * LHS: category MAP (jobs). RHS: active job's assembly L1 modules always listed;
- * subsections and L2 modules under an L1 appear progressively while scrolling it.
+ * LHS: category MAP jobs (levels 1–2).
+ * RHS: assembly L1 modules for the active job — always listed, collapsible.
+ * L2 modules and ==/=== subsections appear only when their L1 row is expanded.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -20,7 +21,7 @@
 
   var SCROLL_LINE = 120;
   var currentChunk = null;
-  var lastRenderedKey = '';
+  var expandedL1ByChunk = {};
 
   function esc(text) {
     var d = document.createElement('div');
@@ -34,94 +35,83 @@
     return el.getBoundingClientRect().top;
   }
 
-  function headingPassed(anchor) {
-    var top = headingTop(anchor);
-    return top !== null && top <= SCROLL_LINE;
-  }
-
-  function collectAnchors(node, out) {
-    if (!node) return;
-    out.push(node.anchor);
-    (node.children || []).forEach(function (child) {
-      collectAnchors(child, out);
-    });
-  }
-
-  function findL1ForAnchor(roots, anchor) {
-    for (var i = 0; i < roots.length; i++) {
-      var anchors = [];
-      collectAnchors(roots[i], anchors);
-      if (anchors.indexOf(anchor) !== -1) return roots[i];
-    }
-    return null;
-  }
-
-  function activeL1Root(roots) {
-    var bestAnchor = null;
-    var bestTop = -Infinity;
-    roots.forEach(function (l1) {
-      var anchors = [];
-      collectAnchors(l1, anchors);
-      anchors.forEach(function (anchor) {
-        var top = headingTop(anchor);
-        if (top !== null && top <= SCROLL_LINE && top > bestTop) {
-          bestTop = top;
-          bestAnchor = anchor;
-        }
-      });
-    });
-    if (!bestAnchor) return null;
-    return findL1ForAnchor(roots, bestAnchor);
-  }
-
-  function progressiveChildren(node) {
-    var visible = [];
-    (node.children || []).forEach(function (child) {
-      if (!headingPassed(child.anchor)) return;
-      var nested = progressiveChildren(child);
-      visible.push({
-        anchor: child.anchor,
-        title: child.title,
-        children: nested,
-      });
-    });
-    return visible;
-  }
-
-  function renderChildNodes(children) {
-    if (!children || !children.length) return '';
+  function renderChildTree(nodes) {
+    if (!nodes || !nodes.length) return '';
     var parts = ['<ul>'];
-    children.forEach(function (child) {
-      parts.push('<li><a href="#' + esc(child.anchor) + '">' + esc(child.title) + '</a>');
-      parts.push(renderChildNodes(child.children));
+    nodes.forEach(function (node) {
+      parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
+      parts.push(renderChildTree(node.children));
       parts.push('</li>');
     });
     parts.push('</ul>');
     return parts.join('');
   }
 
-  function renderChunkRhs(roots, activeL1) {
+  function renderChunkRhs(roots, expandedAnchor) {
+    if (!roots || !roots.length) {
+      return (
+        '<div class="right-toc-title">On this page</div>' +
+        '<p class="right-toc-empty">No sections in this job</p>'
+      );
+    }
+
     var parts = ['<div class="right-toc-title">On this page</div>', '<ul class="rhs-list">'];
     roots.forEach(function (l1) {
-      var isActive = activeL1 && l1.anchor === activeL1.anchor;
-      var visibleKids = isActive ? progressiveChildren(l1) : [];
-
-      if (isActive && visibleKids.length) {
-        parts.push('<li class="rhs-collapsible expanded">');
-        parts.push(
-          '<button type="button" class="rhs-chevron" aria-label="Hide subsections" aria-expanded="true"></button>'
-        );
-        parts.push(
-          '<a href="#' + esc(l1.anchor) + '" class="rhs-parent">' + esc(l1.title) + '</a>'
-        );
-        parts.push(renderChildNodes(visibleKids));
-        parts.push('</li>');
-      } else {
+      var hasChildren = l1.children && l1.children.length;
+      if (!hasChildren) {
         parts.push('<li><a href="#' + esc(l1.anchor) + '">' + esc(l1.title) + '</a></li>');
+        return;
       }
+
+      var expanded = expandedAnchor === l1.anchor;
+      parts.push('<li class="rhs-collapsible' + (expanded ? ' expanded' : '') + '">');
+      parts.push(
+        '<button type="button" class="rhs-chevron" aria-label="' +
+          (expanded ? 'Collapse section' : 'Expand section') +
+          '" aria-expanded="' +
+          (expanded ? 'true' : 'false') +
+          '"></button>'
+      );
+      parts.push(
+        '<a href="#' +
+          esc(l1.anchor) +
+          '" class="rhs-parent">' +
+          esc(l1.title) +
+          '</a>'
+      );
+      parts.push(renderChildTree(l1.children));
+      parts.push('</li>');
     });
     parts.push('</ul>');
     return parts.join('');
+  }
+
+  function bindRhsCollapse(chunk, roots) {
+    rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
+      var link = li.querySelector('a.rhs-parent');
+      if (!link) return;
+      var anchor = link.getAttribute('href').slice(1);
+
+      function toggle() {
+        var next = expandedL1ByChunk[chunk] === anchor ? null : anchor;
+        expandedL1ByChunk[chunk] = next;
+        renderChunk(chunk);
+      }
+
+      var btn = li.querySelector('.rhs-chevron');
+      if (btn) {
+        btn.addEventListener('click', function (e) {
+          e.preventDefault();
+          toggle();
+        });
+      }
+      link.addEventListener('click', function () {
+        if (expandedL1ByChunk[chunk] !== anchor) {
+          expandedL1ByChunk[chunk] = anchor;
+          renderChunk(chunk);
+        }
+      });
+    });
   }
 
   function bindRhsScrollSpy() {
@@ -167,44 +157,51 @@
     return best;
   }
 
-  function syncRhsFromScroll() {
+  function renderChunk(chunk) {
+    var roots = data.rhsByChunk[chunk];
+    var expanded = expandedL1ByChunk[chunk] || null;
+    rhsPanel.innerHTML = renderChunkRhs(roots, expanded);
+    bindRhsCollapse(chunk, roots);
+    bindRhsScrollSpy();
+  }
+
+  function syncChunkFromScroll() {
     var chunk = activeChunkFromScroll();
     if (!chunk || !data.rhsByChunk[chunk]) {
       if (currentChunk !== null) {
         rhsPanel.innerHTML =
           '<div class="right-toc-title">On this page</div>' +
-          '<p class="right-toc-empty">Scroll to a section</p>';
+          '<p class="right-toc-empty">Scroll to a job section</p>';
         currentChunk = null;
-        lastRenderedKey = '';
       }
       return;
     }
-
-    var roots = data.rhsByChunk[chunk];
-    var activeL1 = activeL1Root(roots);
-    var visibleKey = activeL1
-      ? activeL1.anchor + ':' + JSON.stringify(progressiveChildren(activeL1).map(function (c) {
-          return c.anchor;
-        }))
-      : '';
-    var key = chunk + '|' + visibleKey;
-
-    if (key === lastRenderedKey && chunk === currentChunk) {
+    if (chunk !== currentChunk) {
+      currentChunk = chunk;
+      renderChunk(chunk);
+    } else {
       bindRhsScrollSpy();
-      return;
     }
-
-    currentChunk = chunk;
-    lastRenderedKey = key;
-    rhsPanel.innerHTML = renderChunkRhs(roots, activeL1);
-    bindRhsScrollSpy();
   }
 
-  syncRhsFromScroll();
+  syncChunkFromScroll();
 
   var scrollTimer;
   window.addEventListener('scroll', function () {
     clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(syncRhsFromScroll, 50);
+    scrollTimer = setTimeout(syncChunkFromScroll, 80);
   });
+
+  var toc = document.getElementById('toc');
+  if (toc) {
+    toc.addEventListener('click', function (e) {
+      var a = e.target.closest('a[href^="#"]');
+      if (!a) return;
+      var id = a.getAttribute('href').slice(1);
+      if (data.rhsByChunk[id]) {
+        currentChunk = id;
+        renderChunk(id);
+      }
+    });
+  }
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -107,6 +107,15 @@
     if (li) expandRhsItem(li);
   }
 
+  function expandRhsParentForAnchor(anchor) {
+    if (!anchor) return;
+    var selector = 'a.rhs-parent[href="#' + anchor.replace(/"/g, '\\"') + '"]';
+    var parentLink = rhsPanel.querySelector(selector);
+    if (!parentLink) return;
+    var li = parentLink.closest('li.rhs-collapsible');
+    if (li) expandRhsItem(li);
+  }
+
   function renderRhs(chunkAnchor) {
     var nodes = data.rhsByChunk[chunkAnchor];
     if (!nodes || !nodes.length) {
@@ -146,7 +155,9 @@
         l.classList.toggle('active', l === active);
       });
       if (active) {
-        expandParentForAnchor(active.getAttribute('href').slice(1));
+        var activeAnchor = active.getAttribute('href').slice(1);
+        expandParentForAnchor(activeAnchor);
+        expandRhsParentForAnchor(activeAnchor);
       }
     }
 
@@ -205,6 +216,10 @@
       setTimeout(function () {
         renderRhs(id);
       }, 50);
+      return;
     }
+    setTimeout(function () {
+      expandRhsParentForAnchor(id);
+    }, 50);
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,8 +1,9 @@
 /**
- * JTBD map preview: chunk-scoped RHS "On this page" nav.
+ * JTBD map preview: chunk-scoped, scroll-progressive RHS nav.
  *
- * RHS switches with the top-level job (chunk) in view. Within a chunk, only the
- * active parent section's subtree is shown; level-2+ expand as you scroll into them.
+ * - LHS: category MAP jobs (levels 1–2 of product navigation)
+ * - RHS: assembly sections for the active job only; empty until you scroll
+ *   into a section; level-2 entries appear one by one as their headings pass.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -18,8 +19,9 @@
   var rhsPanel = document.getElementById('right-toc');
   if (!rhsPanel || !data.rhsByChunk) return;
 
+  var SCROLL_LINE = 120;
   var currentChunk = null;
-  var currentRootAnchor = null;
+  var lastRenderedKey = '';
 
   function esc(text) {
     var d = document.createElement('div');
@@ -27,142 +29,125 @@
     return d.innerHTML;
   }
 
-  function renderList(nodes, depth, expandRoot) {
-    if (!nodes || !nodes.length) return '';
-    var parts = ['<ul>'];
-    nodes.forEach(function (node) {
-      var hasChildren = node.children && node.children.length;
-      if (hasChildren) {
-        var expanded = expandRoot && depth === 1 ? ' expanded' : '';
-        parts.push('<li class="rhs-collapsible' + expanded + '">');
-        parts.push(
-          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="' +
-            (expanded ? 'true' : 'false') +
-            '"></button>'
-        );
-        parts.push(
-          '<a href="#' +
-            esc(node.anchor) +
-            '" class="rhs-parent">' +
-            esc(node.title) +
-            '</a>'
-        );
-        parts.push(renderList(node.children, depth + 1, false));
-      } else {
-        parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
-      }
-      parts.push('</li>');
+  function headingTop(anchor) {
+    var el = document.getElementById(anchor);
+    if (!el) return null;
+    return el.getBoundingClientRect().top;
+  }
+
+  function headingPassed(anchor) {
+    var top = headingTop(anchor);
+    return top !== null && top <= SCROLL_LINE;
+  }
+
+  function progressiveSubtree(node) {
+    if (!node || !headingPassed(node.anchor)) return null;
+
+    var kids = [];
+    (node.children || []).forEach(function (child) {
+      if (!headingPassed(child.anchor)) return;
+      var nested = progressiveSubtree(child);
+      kids.push(
+        nested || { anchor: child.anchor, title: child.title, children: [] }
+      );
     });
-    parts.push('</ul>');
+
+    return { anchor: node.anchor, title: node.title, children: kids };
+  }
+
+  function renderNode(node) {
+    var parts = [
+      '<li><a href="#' +
+        esc(node.anchor) +
+        '">' +
+        esc(node.title) +
+        '</a>',
+    ];
+    if (node.children && node.children.length) {
+      parts.push('<ul>');
+      node.children.forEach(function (child) {
+        parts.push(renderNode(child));
+      });
+      parts.push('</ul>');
+    }
+    parts.push('</li>');
     return parts.join('');
   }
 
-  function collapseRhsItem(li) {
-    li.classList.remove('expanded');
-    var btn = li.querySelector('.rhs-chevron');
-    if (btn) btn.setAttribute('aria-expanded', 'false');
-  }
-
-  function expandRhsItem(li) {
-    var parentUl = li.parentElement;
-    if (parentUl) {
-      parentUl.querySelectorAll(':scope > li.rhs-collapsible.expanded').forEach(function (other) {
-        if (other !== li) collapseRhsItem(other);
-      });
-    }
-    li.classList.add('expanded');
-    var btn = li.querySelector('.rhs-chevron');
-    if (btn) {
-      btn.setAttribute('aria-expanded', 'true');
-      btn.setAttribute('aria-label', 'Hide subsections');
-    }
-  }
-
-  function toggleRhsItem(li) {
-    if (li.classList.contains('expanded')) {
-      collapseRhsItem(li);
-    } else {
-      expandRhsItem(li);
-    }
-  }
-
-  function bindRhsCollapse() {
-    rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
-      var btn = li.querySelector('.rhs-chevron');
-      var link = li.querySelector('a.rhs-parent');
-      if (btn) {
-        btn.addEventListener('click', function (e) {
-          e.preventDefault();
-          toggleRhsItem(li);
-        });
-      }
-      if (link) {
-        link.addEventListener('click', function () {
-          expandRhsItem(li);
-        });
-      }
-    });
-  }
-
-  function collectAnchors(node, out) {
-    if (!node) return;
-    out.push(node.anchor);
-    (node.children || []).forEach(function (child) {
-      collectAnchors(child, out);
-    });
-  }
-
-  function findRootForAnchor(roots, anchor) {
-    for (var i = 0; i < roots.length; i++) {
-      var anchors = [];
-      collectAnchors(roots[i], anchors);
-      if (anchors.indexOf(anchor) !== -1) return roots[i];
-    }
-    return null;
-  }
-
-  function activeRhsRootInChunk(chunkAnchor) {
-    var roots = data.rhsByChunk[chunkAnchor];
-    if (!roots || !roots.length) return null;
-
-    var bestRoot = null;
-    var bestTop = -Infinity;
-    roots.forEach(function (root) {
-      var anchors = [];
-      collectAnchors(root, anchors);
-      anchors.forEach(function (anchor) {
-        var el = document.getElementById(anchor);
-        if (!el) return;
-        var top = el.getBoundingClientRect().top;
-        if (top <= 120 && top > bestTop) {
-          bestTop = top;
-          bestRoot = root;
-        }
-      });
-    });
-    return bestRoot || roots[0];
-  }
-
-  function expandParentForAnchor(anchor) {
-    if (!anchor) return;
-    var link = rhsPanel.querySelector('a[href="#' + CSS.escape(anchor) + '"]');
-    if (!link) return;
-    var li = link.closest('li.rhs-collapsible');
-    if (li) expandRhsItem(li);
-  }
-
-  function renderRhs(chunkAnchor, rootNode) {
-    if (!rootNode) {
+  function renderProgressiveTree(tree) {
+    if (!tree) {
       rhsPanel.innerHTML =
         '<div class="right-toc-title">On this page</div>' +
-        '<p class="right-toc-empty">No nested sections</p>';
+        '<p class="right-toc-empty">Scroll to a section</p>';
       return;
     }
     rhsPanel.innerHTML =
       '<div class="right-toc-title">On this page</div>' +
-      renderList([rootNode], 1, true);
-    bindRhsCollapse();
+      '<ul class="rhs-list">' +
+      renderNode(tree) +
+      '</ul>';
     bindRhsScrollSpy();
+  }
+
+  function activeSectionInChunk(chunkAnchor) {
+    var roots = data.rhsByChunk[chunkAnchor];
+    if (!roots || !roots.length) return null;
+
+    var active = null;
+    var bestTop = -Infinity;
+    roots.forEach(function (root) {
+      var top = headingTop(root.anchor);
+      if (top === null || top > SCROLL_LINE) return;
+      if (top > bestTop) {
+        bestTop = top;
+        active = root;
+      }
+    });
+    return active;
+  }
+
+  function activeChunkFromScroll() {
+    var best = null;
+    var bestTop = -Infinity;
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var top = headingTop(anchor);
+      if (top === null || top > SCROLL_LINE) return;
+      if (top > bestTop) {
+        bestTop = top;
+        best = anchor;
+      }
+    });
+    return best;
+  }
+
+  function syncRhsFromScroll() {
+    var chunk = activeChunkFromScroll();
+    if (!chunk || !data.rhsByChunk[chunk]) {
+      if (currentChunk !== null) {
+        renderProgressiveTree(null);
+        currentChunk = null;
+        lastRenderedKey = '';
+      }
+      return;
+    }
+
+    var section = activeSectionInChunk(chunk);
+    var tree = section ? progressiveSubtree(section) : null;
+    var key =
+      chunk +
+      '|' +
+      (section ? section.anchor : '') +
+      '|' +
+      JSON.stringify(tree ? tree.children.map(function (c) { return c.anchor; }) : []);
+
+    if (key === lastRenderedKey && chunk === currentChunk) {
+      bindRhsScrollSpy();
+      return;
+    }
+
+    currentChunk = chunk;
+    lastRenderedKey = key;
+    renderProgressiveTree(tree);
   }
 
   function bindRhsScrollSpy() {
@@ -189,91 +174,17 @@
       links.forEach(function (l) {
         l.classList.toggle('active', l === active);
       });
-      if (active) {
-        expandParentForAnchor(active.getAttribute('href').slice(1));
-      }
     }
 
     $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
     sync();
   }
 
-  function markChunkSections() {
-    (data.chunkAnchors || []).forEach(function (anchor) {
-      var el = document.getElementById(anchor);
-      if (!el) return;
-      var section = el.closest('.sect1, .sect2, .sectionbody') || el.parentElement;
-      if (section) section.dataset.chunkAnchor = anchor;
-    });
-  }
-
-  function activeChunkFromScroll() {
-    var best = null;
-    var bestTop = -Infinity;
-    (data.chunkAnchors || []).forEach(function (anchor) {
-      var el = document.getElementById(anchor);
-      if (!el) return;
-      var top = el.getBoundingClientRect().top;
-      if (top <= 120 && top > bestTop) {
-        bestTop = top;
-        best = anchor;
-      }
-    });
-    return best;
-  }
-
-  function syncRhsFromScroll() {
-    var chunk = activeChunkFromScroll();
-    if (!chunk || !data.rhsByChunk[chunk]) {
-      if (currentChunk !== null) {
-        rhsPanel.innerHTML =
-          '<div class="right-toc-title">On this page</div>' +
-          '<p class="right-toc-empty">Scroll to a section</p>';
-        currentChunk = null;
-        currentRootAnchor = null;
-      }
-      return;
-    }
-
-    var root = activeRhsRootInChunk(chunk);
-    var rootAnchor = root ? root.anchor : null;
-    if (chunk === currentChunk && rootAnchor === currentRootAnchor) {
-      bindRhsScrollSpy();
-      return;
-    }
-
-    currentChunk = chunk;
-    currentRootAnchor = rootAnchor;
-    renderRhs(chunk, root);
-  }
-
-  markChunkSections();
   syncRhsFromScroll();
 
   var scrollTimer;
   window.addEventListener('scroll', function () {
     clearTimeout(scrollTimer);
-    scrollTimer = setTimeout(syncRhsFromScroll, 80);
-  });
-
-  document.getElementById('toc').addEventListener('click', function (e) {
-    var a = e.target.closest('a[href^="#"]');
-    if (!a) return;
-    var id = a.getAttribute('href').slice(1);
-    if (data.rhsByChunk[id]) {
-      currentChunk = id;
-      currentRootAnchor = null;
-      setTimeout(syncRhsFromScroll, 50);
-      return;
-    }
-    setTimeout(function () {
-      if (!currentChunk) return;
-      var roots = data.rhsByChunk[currentChunk];
-      var root = findRootForAnchor(roots, id);
-      if (root) {
-        currentRootAnchor = root.anchor;
-        renderRhs(currentChunk, root);
-      }
-    }, 50);
+    scrollTimer = setTimeout(syncRhsFromScroll, 50);
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,6 +1,9 @@
 /**
  * JTBD map preview: right-hand "On this page" nav for chunked job sections.
  * Reads #map-nav-data JSON emitted by preview/map_nav.py.
+ *
+ * Level-1 RHS entries are always visible; level-2+ children expand only when
+ * their parent is clicked (accordion — one expanded section at a time).
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -26,15 +29,82 @@
     if (!nodes || !nodes.length) return '';
     var parts = ['<ul>'];
     nodes.forEach(function (node) {
-      var cls = depth > 2 ? ' class="right-toc-too-deep"' : '';
-      parts.push('<li' + cls + '><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
-      if (node.children && node.children.length) {
+      var hasChildren = node.children && node.children.length;
+      if (hasChildren) {
+        parts.push('<li class="rhs-collapsible">');
+        parts.push(
+          '<button type="button" class="rhs-chevron" aria-label="Show subsections" aria-expanded="false"></button>'
+        );
+        parts.push(
+          '<a href="#' +
+            esc(node.anchor) +
+            '" class="rhs-parent">' +
+            esc(node.title) +
+            '</a>'
+        );
         parts.push(renderList(node.children, depth + 1));
+      } else {
+        parts.push('<li><a href="#' + esc(node.anchor) + '">' + esc(node.title) + '</a>');
       }
       parts.push('</li>');
     });
     parts.push('</ul>');
     return parts.join('');
+  }
+
+  function collapseRhsItem(li) {
+    li.classList.remove('expanded');
+    var btn = li.querySelector('.rhs-chevron');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+
+  function expandRhsItem(li) {
+    var parentUl = li.parentElement;
+    if (parentUl) {
+      parentUl.querySelectorAll(':scope > li.rhs-collapsible.expanded').forEach(function (other) {
+        if (other !== li) collapseRhsItem(other);
+      });
+    }
+    li.classList.add('expanded');
+    var btn = li.querySelector('.rhs-chevron');
+    if (btn) {
+      btn.setAttribute('aria-expanded', 'true');
+      btn.setAttribute('aria-label', 'Hide subsections');
+    }
+  }
+
+  function toggleRhsItem(li) {
+    if (li.classList.contains('expanded')) {
+      collapseRhsItem(li);
+    } else {
+      expandRhsItem(li);
+    }
+  }
+
+  function bindRhsCollapse() {
+    rhsPanel.querySelectorAll('li.rhs-collapsible').forEach(function (li) {
+      var btn = li.querySelector('.rhs-chevron');
+      var link = li.querySelector('a.rhs-parent');
+      if (btn) {
+        btn.addEventListener('click', function (e) {
+          e.preventDefault();
+          toggleRhsItem(li);
+        });
+      }
+      if (link) {
+        link.addEventListener('click', function () {
+          expandRhsItem(li);
+        });
+      }
+    });
+  }
+
+  function expandParentForAnchor(anchor) {
+    if (!anchor) return;
+    var link = rhsPanel.querySelector('a[href="#' + CSS.escape(anchor) + '"]');
+    if (!link) return;
+    var li = link.closest('li.rhs-collapsible');
+    if (li) expandRhsItem(li);
   }
 
   function renderRhs(chunkAnchor) {
@@ -47,17 +117,8 @@
     }
     rhsPanel.innerHTML =
       '<div class="right-toc-title">On this page</div>' + renderList(nodes, 1);
+    bindRhsCollapse();
     bindRhsScrollSpy();
-  }
-
-  function chunkForElement(el) {
-    while (el && el !== document.body) {
-      if (el.dataset && el.dataset.chunkAnchor) {
-        return el.dataset.chunkAnchor;
-      }
-      el = el.parentElement;
-    }
-    return null;
   }
 
   function bindRhsScrollSpy() {
@@ -84,6 +145,9 @@
       links.forEach(function (l) {
         l.classList.toggle('active', l === active);
       });
+      if (active) {
+        expandParentForAnchor(active.getAttribute('href').slice(1));
+      }
     }
 
     $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
@@ -138,7 +202,9 @@
     var id = a.getAttribute('href').slice(1);
     if (data.rhsByChunk[id]) {
       current = id;
-      setTimeout(function () { renderRhs(id); }, 50);
+      setTimeout(function () {
+        renderRhs(id);
+      }, 50);
     }
   });
 })();

--- a/preview/assets/js/map-nav.js
+++ b/preview/assets/js/map-nav.js
@@ -1,9 +1,8 @@
 /**
- * JTBD map preview: chunk-scoped, scroll-progressive RHS nav.
+ * JTBD map preview: RHS mirrors assembly structure (L1 + nested L2/==/===).
  *
- * - LHS: category MAP jobs (levels 1–2 of product navigation)
- * - RHS: assembly sections for the active job only; empty until you scroll
- *   into a section; level-2 entries appear one by one as their headings pass.
+ * LHS: category MAP (jobs). RHS: active job's assembly L1 modules always listed;
+ * subsections and L2 modules under an L1 appear progressively while scrolling it.
  */
 (function () {
   var dataEl = document.getElementById('map-nav-data');
@@ -40,114 +39,89 @@
     return top !== null && top <= SCROLL_LINE;
   }
 
-  function progressiveSubtree(node) {
-    if (!node || !headingPassed(node.anchor)) return null;
-
-    var kids = [];
+  function collectAnchors(node, out) {
+    if (!node) return;
+    out.push(node.anchor);
     (node.children || []).forEach(function (child) {
-      if (!headingPassed(child.anchor)) return;
-      var nested = progressiveSubtree(child);
-      kids.push(
-        nested || { anchor: child.anchor, title: child.title, children: [] }
-      );
+      collectAnchors(child, out);
     });
-
-    return { anchor: node.anchor, title: node.title, children: kids };
   }
 
-  function renderNode(node) {
-    var parts = [
-      '<li><a href="#' +
-        esc(node.anchor) +
-        '">' +
-        esc(node.title) +
-        '</a>',
-    ];
-    if (node.children && node.children.length) {
-      parts.push('<ul>');
-      node.children.forEach(function (child) {
-        parts.push(renderNode(child));
-      });
-      parts.push('</ul>');
+  function findL1ForAnchor(roots, anchor) {
+    for (var i = 0; i < roots.length; i++) {
+      var anchors = [];
+      collectAnchors(roots[i], anchors);
+      if (anchors.indexOf(anchor) !== -1) return roots[i];
     }
-    parts.push('</li>');
+    return null;
+  }
+
+  function activeL1Root(roots) {
+    var bestAnchor = null;
+    var bestTop = -Infinity;
+    roots.forEach(function (l1) {
+      var anchors = [];
+      collectAnchors(l1, anchors);
+      anchors.forEach(function (anchor) {
+        var top = headingTop(anchor);
+        if (top !== null && top <= SCROLL_LINE && top > bestTop) {
+          bestTop = top;
+          bestAnchor = anchor;
+        }
+      });
+    });
+    if (!bestAnchor) return null;
+    return findL1ForAnchor(roots, bestAnchor);
+  }
+
+  function progressiveChildren(node) {
+    var visible = [];
+    (node.children || []).forEach(function (child) {
+      if (!headingPassed(child.anchor)) return;
+      var nested = progressiveChildren(child);
+      visible.push({
+        anchor: child.anchor,
+        title: child.title,
+        children: nested,
+      });
+    });
+    return visible;
+  }
+
+  function renderChildNodes(children) {
+    if (!children || !children.length) return '';
+    var parts = ['<ul>'];
+    children.forEach(function (child) {
+      parts.push('<li><a href="#' + esc(child.anchor) + '">' + esc(child.title) + '</a>');
+      parts.push(renderChildNodes(child.children));
+      parts.push('</li>');
+    });
+    parts.push('</ul>');
     return parts.join('');
   }
 
-  function renderProgressiveTree(tree) {
-    if (!tree) {
-      rhsPanel.innerHTML =
-        '<div class="right-toc-title">On this page</div>' +
-        '<p class="right-toc-empty">Scroll to a section</p>';
-      return;
-    }
-    rhsPanel.innerHTML =
-      '<div class="right-toc-title">On this page</div>' +
-      '<ul class="rhs-list">' +
-      renderNode(tree) +
-      '</ul>';
-    bindRhsScrollSpy();
-  }
+  function renderChunkRhs(roots, activeL1) {
+    var parts = ['<div class="right-toc-title">On this page</div>', '<ul class="rhs-list">'];
+    roots.forEach(function (l1) {
+      var isActive = activeL1 && l1.anchor === activeL1.anchor;
+      var visibleKids = isActive ? progressiveChildren(l1) : [];
 
-  function activeSectionInChunk(chunkAnchor) {
-    var roots = data.rhsByChunk[chunkAnchor];
-    if (!roots || !roots.length) return null;
-
-    var active = null;
-    var bestTop = -Infinity;
-    roots.forEach(function (root) {
-      var top = headingTop(root.anchor);
-      if (top === null || top > SCROLL_LINE) return;
-      if (top > bestTop) {
-        bestTop = top;
-        active = root;
+      if (isActive && visibleKids.length) {
+        parts.push('<li class="rhs-collapsible expanded">');
+        parts.push(
+          '<button type="button" class="rhs-chevron" aria-label="Hide subsections" aria-expanded="true"></button>'
+        );
+        parts.push(
+          '<a href="#' + esc(l1.anchor) + '" class="rhs-parent">' + esc(l1.title) + '</a>'
+        );
+        parts.push(renderChildNodes(visibleKids));
+        parts.push('</li>');
+      } else {
+        parts.push('<li><a href="#' + esc(l1.anchor) + '">' + esc(l1.title) + '</a></li>');
       }
     });
-    return active;
-  }
-
-  function activeChunkFromScroll() {
-    var best = null;
-    var bestTop = -Infinity;
-    (data.chunkAnchors || []).forEach(function (anchor) {
-      var top = headingTop(anchor);
-      if (top === null || top > SCROLL_LINE) return;
-      if (top > bestTop) {
-        bestTop = top;
-        best = anchor;
-      }
-    });
-    return best;
-  }
-
-  function syncRhsFromScroll() {
-    var chunk = activeChunkFromScroll();
-    if (!chunk || !data.rhsByChunk[chunk]) {
-      if (currentChunk !== null) {
-        renderProgressiveTree(null);
-        currentChunk = null;
-        lastRenderedKey = '';
-      }
-      return;
-    }
-
-    var section = activeSectionInChunk(chunk);
-    var tree = section ? progressiveSubtree(section) : null;
-    var key =
-      chunk +
-      '|' +
-      (section ? section.anchor : '') +
-      '|' +
-      JSON.stringify(tree ? tree.children.map(function (c) { return c.anchor; }) : []);
-
-    if (key === lastRenderedKey && chunk === currentChunk) {
-      bindRhsScrollSpy();
-      return;
-    }
-
-    currentChunk = chunk;
-    lastRenderedKey = key;
-    renderProgressiveTree(tree);
+    parts.push('</ul>');
+    return parts.join('');
   }
 
   function bindRhsScrollSpy() {
@@ -178,6 +152,52 @@
 
     $(window).off('scroll.mapNavRhs').on('scroll.mapNavRhs', sync);
     sync();
+  }
+
+  function activeChunkFromScroll() {
+    var best = null;
+    var bestTop = -Infinity;
+    (data.chunkAnchors || []).forEach(function (anchor) {
+      var top = headingTop(anchor);
+      if (top !== null && top <= SCROLL_LINE && top > bestTop) {
+        bestTop = top;
+        best = anchor;
+      }
+    });
+    return best;
+  }
+
+  function syncRhsFromScroll() {
+    var chunk = activeChunkFromScroll();
+    if (!chunk || !data.rhsByChunk[chunk]) {
+      if (currentChunk !== null) {
+        rhsPanel.innerHTML =
+          '<div class="right-toc-title">On this page</div>' +
+          '<p class="right-toc-empty">Scroll to a section</p>';
+        currentChunk = null;
+        lastRenderedKey = '';
+      }
+      return;
+    }
+
+    var roots = data.rhsByChunk[chunk];
+    var activeL1 = activeL1Root(roots);
+    var visibleKey = activeL1
+      ? activeL1.anchor + ':' + JSON.stringify(progressiveChildren(activeL1).map(function (c) {
+          return c.anchor;
+        }))
+      : '';
+    var key = chunk + '|' + visibleKey;
+
+    if (key === lastRenderedKey && chunk === currentChunk) {
+      bindRhsScrollSpy();
+      return;
+    }
+
+    currentChunk = chunk;
+    lastRenderedKey = key;
+    rhsPanel.innerHTML = renderChunkRhs(roots, activeL1);
+    bindRhsScrollSpy();
   }
 
   syncRhsFromScroll();

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -329,24 +329,34 @@ def align_all_anchors(nav: MapNav, headings: list[tuple[str, str]]) -> None:
             index = align_anchors_preorder(node, headings, index)
 
 
-def render_toc_list(nodes: list[NavNode], depth: int = 1) -> str:
+def render_toc_list(nodes: list[NavNode], depth: int = 1, *, expanded: bool = True) -> str:
     if not nodes:
         return ''
     cls = 'sectlevel1' if depth == 1 else f'sectlevel{depth}'
     parts = [f'<ul class="{cls}">']
     for node in nodes:
         has_children = bool(node.children)
-        li_attrs = ' class="toc-collapsible expanded"' if has_children else ''
+        if expanded:
+            li_attrs = ' class="toc-collapsible expanded"' if has_children else ''
+        else:
+            li_attrs = ' class="rhs-collapsible"' if has_children else ''
         parts.append(f'<li{li_attrs}>')
         if has_children:
-            parts.append(
-                '<button type="button" class="toc-chevron" '
-                'aria-label="Collapse section" aria-expanded="true"></button>'
-            )
+            if expanded:
+                parts.append(
+                    '<button type="button" class="toc-chevron" '
+                    'aria-label="Collapse section" aria-expanded="true"></button>'
+                )
+            else:
+                parts.append(
+                    '<button type="button" class="rhs-chevron" '
+                    'aria-label="Show subsections" aria-expanded="false"></button>'
+                )
         href = f'#{html.escape(node.anchor)}' if node.anchor else '#'
-        parts.append(f'<a href="{href}">{html.escape(node.title)}</a>')
+        link_cls = ' class="rhs-parent"' if has_children and not expanded else ''
+        parts.append(f'<a href="{href}"{link_cls}>{html.escape(node.title)}</a>')
         if has_children:
-            parts.append(render_toc_list(node.children, depth + 1))
+            parts.append(render_toc_list(node.children, depth + 1, expanded=expanded))
         parts.append('</li>')
     parts.append('</ul>')
     return ''.join(parts)
@@ -377,7 +387,7 @@ def render_initial_rhs(nav: MapNav) -> str:
         return ''
     first_key = next(iter(nav.rhs_by_chunk))
     nodes = nav.rhs_by_chunk[first_key]
-    inner = render_toc_list(nodes, 1).replace('class="sectlevel1"', 'class="rhs-list"')
+    inner = render_toc_list(nodes, 1, expanded=False).replace('class="sectlevel1"', 'class="rhs-list"')
     return (
         '<aside id="right-toc" aria-label="On this page">'
         '<div class="right-toc-title">On this page</div>'

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -207,28 +207,58 @@ def strip_toc_no(nodes: list[NavNode]) -> list[NavNode]:
     return result
 
 
-def extract_toc_no_children(children: list[NavNode]) -> list[NavNode]:
-    extracted: list[NavNode] = []
-    for node in children:
-        if node.toc_no:
-            extracted.append(clone_node(node, children=extract_toc_no_children(node.children)))
-        else:
-            extracted.extend(extract_toc_no_children(node.children))
-    return extracted
+def build_rhs_for_chunk(all_includes: list[NavNode], attrs: dict[str, str]) -> list[NavNode]:
+    """Build per-chunk RHS roots from flat include order.
 
+    Release-notes pattern (+1 parent, no == subs, +2 toc=no run): nest toc=no modules
+    under the parent with their == subsections as grandchildren.
 
-def build_rhs_roots(full_tree: list[NavNode]) -> list[NavNode]:
+    Discover pattern (+1 parent with == subs, +2 toc=no siblings): parent gets == subs
+    only; each toc=no module is its own RHS root when reached in the include list.
+    """
     roots: list[NavNode] = []
-    for node in full_tree:
+    i = 0
+    while i < len(all_includes):
+        node = all_includes[i]
         if node.toc_no:
+            subs = [
+                NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
+                for sub in subsection_nodes(node.source, attrs)
+            ]
+            roots.append(clone_node(node, children=subs))
+            i += 1
             continue
-        toc_children = extract_toc_no_children(node.children)
-        if toc_children:
-            roots.append(clone_node(node, children=toc_children))
-            continue
-        for child in node.children:
-            if not child.toc_no:
-                roots.extend(build_rhs_roots([child]))
+
+        inline_subs = subsection_nodes(node.source, attrs)
+        j = i + 1
+        toc_run: list[NavNode] = []
+        while j < len(all_includes):
+            nxt = all_includes[j]
+            if nxt.toc_no and nxt.leveloffset > node.leveloffset:
+                toc_run.append(nxt)
+                j += 1
+            else:
+                break
+
+        if toc_run and not inline_subs:
+            children = []
+            for toc_node in toc_run:
+                subs = [
+                    NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=toc_node.source)
+                    for sub in subsection_nodes(toc_node.source, attrs)
+                ]
+                children.append(clone_node(toc_node, children=subs))
+            roots.append(clone_node(node, children=children))
+            i = j
+        else:
+            if inline_subs:
+                subs = [
+                    NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
+                    for sub in inline_subs
+                ]
+                roots.append(clone_node(node, children=subs))
+            i += 1
+
     return roots
 
 
@@ -269,7 +299,6 @@ def build_map_nav(master: pathlib.Path) -> MapNav:
     root = NavNode(title=title, anchor=anchor, leveloffset=0, source=master)
     rhs_by_chunk: dict[str, list[NavNode]] = {}
     _expand_nav(root, master, attrs, rhs_by_chunk, chunk_anchor=None, visited=set())
-    attach_subsections(root, attrs)
     for chunk_key, nodes in list(rhs_by_chunk.items()):
         attach_subsections_list(nodes, attrs)
     return MapNav(root=root, rhs_by_chunk=rhs_by_chunk)
@@ -322,12 +351,9 @@ def _expand_nav(
     full_tree = nest_by_leveloffset(all_includes)
     lhs_parent.children.extend(strip_toc_no(full_tree))
 
-    if chunk_anchor:
-        rhs_roots = build_rhs_roots(full_tree)
-        if rhs_roots:
-            existing = rhs_by_chunk.get(chunk_anchor, [])
-            existing.extend(rhs_roots)
-            rhs_by_chunk[chunk_anchor] = existing
+    if is_chunk_file(path):
+        _, chunk_key = file_title_and_block_id(path, attrs)
+        rhs_by_chunk[chunk_key] = build_rhs_for_chunk(all_includes, attrs)
 
     for child in lhs_parent.children:
         if not child.source:

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -222,14 +222,29 @@ def lhs_visible_anchors(full_tree: list[NavNode]) -> set[str]:
     return {node.anchor for node in strip_toc_no(full_tree) if node.anchor}
 
 
+def has_subsection_children(node: NavNode) -> bool:
+    """True when the node has ==/=== subs parsed from module source (no source path)."""
+    return any(not child.source for child in node.children)
+
+
 def omit_lhs_modules(roots: list[NavNode], lhs_anchors: set[str]) -> list[NavNode]:
-    """Replace LHS-visible assembly modules with their in-page children on the RHS."""
+    """Adjust RHS for LHS-visible modules.
+
+    - No nested content: omit (e.g. About Red Hat Quay).
+    - Module has ==/=== subs: keep as collapsible RHS parent (e.g. arch-intro).
+    - toc_no-only wrapper: promote children (e.g. RHSA release entry).
+    """
     result: list[NavNode] = []
     for root in roots:
-        if root.anchor in lhs_anchors:
-            result.extend(root.children)
-        else:
+        if root.anchor not in lhs_anchors:
             result.append(root)
+            continue
+        if not root.children:
+            continue
+        if has_subsection_children(root):
+            result.append(root)
+        else:
+            result.extend(root.children)
     return result
 
 

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -20,6 +20,7 @@ INCLUDE_RE = re.compile(r'^include::(.+?)\[(.*)\]\s*$')
 ATTR_RE = re.compile(r'([\w-]+)=["\']?([^"\',\]]*)["\']?')
 BLOCK_ID_RE = re.compile(r'^\[id="([^"]+)"\]')
 SECTION2_RE = re.compile(r'^== (.+)$')
+SECTION3_RE = re.compile(r'^=== (.+)$')
 HEADING_RE = re.compile(
     r'<h([1-6])\s+id="([^"]+)"[^>]*>(.*?)</h[1-6]>',
     re.IGNORECASE | re.DOTALL,
@@ -207,59 +208,19 @@ def strip_toc_no(nodes: list[NavNode]) -> list[NavNode]:
     return result
 
 
-def build_rhs_for_chunk(all_includes: list[NavNode], attrs: dict[str, str]) -> list[NavNode]:
-    """Build per-chunk RHS roots from flat include order.
+def build_rhs_node(node: NavNode, attrs: dict[str, str]) -> NavNode:
+    """RHS node: ==/=== subs from source, then nested include children (L2 modules)."""
+    children: list[NavNode] = []
+    if node.source:
+        children.extend(subsection_nodes(node.source, attrs))
+    for child in node.children:
+        children.append(build_rhs_node(child, attrs))
+    return clone_node(node, children=children)
 
-    Release-notes pattern (+1 parent, no == subs, +2 toc=no run): nest toc=no modules
-    under the parent with their == subsections as grandchildren.
 
-    Discover pattern (+1 parent with == subs, +2 toc=no siblings): parent gets == subs
-    only; each toc=no module is its own RHS root when reached in the include list.
-    """
-    roots: list[NavNode] = []
-    i = 0
-    while i < len(all_includes):
-        node = all_includes[i]
-        if node.toc_no:
-            subs = [
-                NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
-                for sub in subsection_nodes(node.source, attrs)
-            ]
-            roots.append(clone_node(node, children=subs))
-            i += 1
-            continue
-
-        inline_subs = subsection_nodes(node.source, attrs)
-        j = i + 1
-        toc_run: list[NavNode] = []
-        while j < len(all_includes):
-            nxt = all_includes[j]
-            if nxt.toc_no and nxt.leveloffset > node.leveloffset:
-                toc_run.append(nxt)
-                j += 1
-            else:
-                break
-
-        if toc_run and not inline_subs:
-            children = []
-            for toc_node in toc_run:
-                subs = [
-                    NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=toc_node.source)
-                    for sub in subsection_nodes(toc_node.source, attrs)
-                ]
-                children.append(clone_node(toc_node, children=subs))
-            roots.append(clone_node(node, children=children))
-            i = j
-        else:
-            if inline_subs:
-                subs = [
-                    NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
-                    for sub in inline_subs
-                ]
-                roots.append(clone_node(node, children=subs))
-            i += 1
-
-    return roots
+def build_rhs_for_chunk(full_tree: list[NavNode], attrs: dict[str, str]) -> list[NavNode]:
+    """Assembly L1 modules as RHS roots; L2 includes and ==/=== nested under their L1 parent."""
+    return [build_rhs_node(node, attrs) for node in full_tree]
 
 
 def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:
@@ -267,6 +228,7 @@ def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) ->
     past_title = False
     pending_id = ''
     merged = {**(attrs or {}), **file_attrs(path)}
+    stack: list[NavNode] = []
     for line in read_lines(path):
         stripped = line.strip()
         if not past_title and stripped.startswith('= '):
@@ -278,12 +240,27 @@ def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) ->
         if m:
             pending_id = m.group(1)
             continue
-        m = SECTION2_RE.match(stripped)
-        if m:
-            title = substitute_attrs(m.group(1).strip(), merged)
-            anchor = pending_id or slug(title)
-            nodes.append(NavNode(title=title, anchor=anchor, leveloffset=0))
-            pending_id = ''
+        level = 0
+        title_text = ''
+        m2 = SECTION2_RE.match(stripped)
+        m3 = SECTION3_RE.match(stripped)
+        if m2:
+            level, title_text = 2, m2.group(1).strip()
+        elif m3:
+            level, title_text = 3, m3.group(1).strip()
+        else:
+            continue
+        title = substitute_attrs(title_text, merged)
+        anchor = pending_id or slug(title)
+        node = NavNode(title=title, anchor=anchor, leveloffset=level)
+        while stack and stack[-1].leveloffset >= level:
+            stack.pop()
+        if stack:
+            stack[-1].children.append(node)
+        else:
+            nodes.append(node)
+        stack.append(node)
+        pending_id = ''
     return nodes
 
 
@@ -336,7 +313,7 @@ def _expand_nav(
 
     if is_chunk_file(path):
         _, chunk_key = file_title_and_block_id(path, attrs)
-        rhs_by_chunk[chunk_key] = build_rhs_for_chunk(all_includes, attrs)
+        rhs_by_chunk[chunk_key] = build_rhs_for_chunk(full_tree, attrs)
 
     for child in lhs_parent.children:
         if not child.source:

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""
+JTBD map navigation for Surge preview (LHS + RHS).
+
+LHS: map entries staged by leveloffset (+1..+4), excluding toc="no" under a chunk.
+RHS: toc="no" entries nested under :chunk-to-content: jobs, plus == subsections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import pathlib
+import re
+import sys
+from dataclasses import dataclass, field
+
+INCLUDE_RE = re.compile(r'^include::(.+?)\[(.*)\]\s*$')
+ATTR_RE = re.compile(r'([\w-]+)=["\']?([^"\',\]]*)["\']?')
+BLOCK_ID_RE = re.compile(r'^\[id="([^"]+)"\]')
+SECTION2_RE = re.compile(r'^== (.+)$')
+HEADING_RE = re.compile(
+    r'<h([1-6])\s+id="([^"]+)"[^>]*>(.*?)</h[1-6]>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass
+class NavNode:
+    title: str
+    anchor: str = ''
+    leveloffset: int = 1
+    source: pathlib.Path | None = None
+    toc_no: bool = False
+    children: list[NavNode] = field(default_factory=list)
+
+
+def parse_attrs(attr_str: str) -> dict[str, str]:
+    return {k: v for k, v in ATTR_RE.findall(attr_str)}
+
+
+def read_lines(path: pathlib.Path) -> list[str]:
+    return path.read_text(encoding='utf-8').splitlines()
+
+
+def resolve_include(target: str, base_dir: pathlib.Path) -> pathlib.Path | None:
+    candidate = (base_dir / target).resolve()
+    return candidate if candidate.is_file() else None
+
+
+def file_attrs(path: pathlib.Path) -> dict[str, str]:
+    attrs: dict[str, str] = {}
+    for line in read_lines(path):
+        stripped = line.strip()
+        if stripped.startswith(':') and stripped.endswith(':') and ': ' not in stripped:
+            continue
+        if stripped.startswith('= '):
+            break
+        if stripped.startswith(':') and ':' in stripped[1:]:
+            key, _, val = stripped[1:].partition(':')
+            attrs[key.strip()] = val.strip()
+    return attrs
+
+
+def is_chunk_file(path: pathlib.Path) -> bool:
+    for line in read_lines(path):
+        if line.strip() == ':chunk-to-content:':
+            return True
+        if line.startswith('= '):
+            break
+    return False
+
+
+def load_preview_attrs(master: pathlib.Path) -> dict[str, str]:
+    attrs: dict[str, str] = {}
+    pending: list[pathlib.Path] = [master.resolve()]
+    seen: set[pathlib.Path] = set()
+    while pending:
+        path = pending.pop(0)
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
+        past_title = False
+        for line in read_lines(path):
+            if line.lstrip().startswith('//'):
+                continue
+            if not past_title and line.startswith('= '):
+                past_title = True
+                continue
+            if past_title:
+                break
+            stripped = line.strip()
+            m = INCLUDE_RE.match(stripped)
+            if m:
+                inc = resolve_include(m.group(1), path.parent)
+                if inc:
+                    pending.append(inc)
+                continue
+            if stripped.startswith(':') and not stripped.startswith('::'):
+                key, _, val = stripped[1:].partition(':')
+                attrs[key.strip()] = val.strip()
+    return attrs
+
+
+def substitute_attrs(text: str, attrs: dict[str, str]) -> dict[str, str] | str:
+    if isinstance(text, str):
+        for key, val in attrs.items():
+            text = text.replace(f'{{{key}}}', val)
+        return text
+    return text
+
+
+def file_title_and_block_id(path: pathlib.Path, attrs: dict[str, str] | None = None) -> tuple[str, str]:
+    local = file_attrs(path)
+    merged = {**(attrs or {}), **local}
+    title = ''
+    block_id = ''
+    for line in read_lines(path):
+        stripped = line.strip()
+        m = BLOCK_ID_RE.match(stripped)
+        if m:
+            block_id = substitute_attrs(m.group(1), merged)
+            continue
+        if stripped.startswith('= '):
+            title = substitute_attrs(stripped[2:].strip(), merged)
+            break
+    if not title:
+        title = path.stem.replace('-', ' ').replace('_', ' ').title()
+    if not block_id:
+        block_id = slug(title)
+    return title, block_id
+
+
+def slug(text: str) -> str:
+    s = text.lower()
+    s = re.sub(r'[^a-z0-9]+', '_', s)
+    return s.strip('_')
+
+
+def normalize_title(text: str) -> str:
+    text = html.unescape(re.sub(r'<[^>]+>', '', text))
+    return re.sub(r'\s+', ' ', text).strip().lower()
+
+
+def collect_includes(path: pathlib.Path) -> list[tuple[pathlib.Path, int, bool]]:
+    items: list[tuple[pathlib.Path, int, bool]] = []
+    past_title = False
+    for line in read_lines(path):
+        if line.lstrip().startswith('//'):
+            continue
+        if not past_title and line.startswith('= '):
+            past_title = True
+            continue
+        if not past_title:
+            continue
+        m = INCLUDE_RE.match(line.strip())
+        if not m:
+            continue
+        target, attr_str = m.group(1), m.group(2)
+        resolved = resolve_include(target, path.parent)
+        if not resolved:
+            continue
+        attrs = parse_attrs(attr_str)
+        lo = int(str(attrs.get('leveloffset', '+1')).lstrip('+'))
+        toc_no = attrs.get('toc') == 'no'
+        items.append((resolved, lo, toc_no))
+    return items
+
+
+def nest_by_leveloffset(flat: list[NavNode]) -> list[NavNode]:
+    if not flat:
+        return []
+
+    @dataclass
+    class StackNode:
+        leveloffset: int
+        children: list[NavNode]
+
+    root = StackNode(leveloffset=0, children=[])
+    stack = [root]
+    for node in flat:
+        while len(stack) > 1 and node.leveloffset <= stack[-1].leveloffset:
+            stack.pop()
+        stack[-1].children.append(node)
+        stack.append(StackNode(leveloffset=node.leveloffset, children=node.children))
+    return root.children
+
+
+def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:
+    nodes: list[NavNode] = []
+    past_title = False
+    pending_id = ''
+    merged = {**(attrs or {}), **file_attrs(path)}
+    for line in read_lines(path):
+        stripped = line.strip()
+        if not past_title and stripped.startswith('= '):
+            past_title = True
+            continue
+        if not past_title:
+            continue
+        m = BLOCK_ID_RE.match(stripped)
+        if m:
+            pending_id = m.group(1)
+            continue
+        m = SECTION2_RE.match(stripped)
+        if m:
+            title = substitute_attrs(m.group(1).strip(), merged)
+            anchor = pending_id or slug(title)
+            nodes.append(NavNode(title=title, anchor=anchor, leveloffset=0))
+            pending_id = ''
+    return nodes
+
+
+@dataclass
+class MapNav:
+    root: NavNode
+    rhs_by_chunk: dict[str, list[NavNode]] = field(default_factory=dict)
+
+
+def build_map_nav(master: pathlib.Path) -> MapNav:
+    attrs = load_preview_attrs(master)
+    title, anchor = file_title_and_block_id(master, attrs)
+    root = NavNode(title=title, anchor=anchor, leveloffset=0, source=master)
+    rhs_by_chunk: dict[str, list[NavNode]] = {}
+    _expand_nav(root, master, attrs, rhs_by_chunk, chunk_anchor=None, visited=set())
+    attach_subsections(root, attrs)
+    for chunk_key, nodes in list(rhs_by_chunk.items()):
+        attach_subsections_list(nodes, attrs)
+    return MapNav(root=root, rhs_by_chunk=rhs_by_chunk)
+
+
+def attach_subsections_list(nodes: list[NavNode], attrs: dict[str, str] | None) -> None:
+    for node in nodes:
+        attach_subsections(node, attrs)
+
+
+def attach_subsections(node: NavNode, attrs: dict[str, str] | None = None) -> None:
+    if node.source and node.source.suffix == '.adoc':
+        has_subs = any(c.leveloffset == 0 for c in node.children)
+        if not has_subs:
+            for sub in subsection_nodes(node.source, attrs):
+                node.children.append(sub)
+    for child in node.children:
+        attach_subsections(child, attrs)
+
+
+def _expand_nav(
+    lhs_parent: NavNode,
+    path: pathlib.Path,
+    attrs: dict[str, str],
+    rhs_by_chunk: dict[str, list[NavNode]],
+    chunk_anchor: str | None,
+    visited: set[pathlib.Path],
+) -> None:
+    real = path.resolve()
+    if real in visited:
+        return
+    visited.add(real)
+
+    if is_chunk_file(path):
+        _, chunk_anchor = file_title_and_block_id(path, attrs)
+
+    flat_lhs: list[NavNode] = []
+    flat_rhs: list[NavNode] = []
+
+    for inc_path, leveloffset, toc_no in collect_includes(path):
+        title, anchor = file_title_and_block_id(inc_path, attrs)
+        node = NavNode(
+            title=title,
+            anchor=anchor,
+            leveloffset=leveloffset,
+            source=inc_path,
+            toc_no=toc_no,
+        )
+        if chunk_anchor and toc_no:
+            flat_rhs.append(node)
+        else:
+            flat_lhs.append(node)
+
+    lhs_parent.children.extend(nest_by_leveloffset(flat_lhs))
+
+    if chunk_anchor and flat_rhs:
+        existing = rhs_by_chunk.get(chunk_anchor, [])
+        existing.extend(nest_by_leveloffset(flat_rhs))
+        rhs_by_chunk[chunk_anchor] = existing
+
+    for child in lhs_parent.children:
+        if not child.source:
+            continue
+        content_type = file_attrs(child.source).get('_mod-docs-content-type', '')
+        if content_type in ('MAP', 'ASSEMBLY'):
+            child_chunk = chunk_anchor
+            if is_chunk_file(child.source):
+                _, child_chunk = file_title_and_block_id(child.source, attrs)
+            _expand_nav(child, child.source, attrs, rhs_by_chunk, child_chunk, visited)
+
+
+def extract_html_headings(html_text: str) -> list[tuple[str, str]]:
+    content_match = re.search(
+        r'<div id="content">(.*)</div>\s*(?:<div id="footer|<footer|$)',
+        html_text,
+        re.DOTALL,
+    )
+    scope = content_match.group(1) if content_match else html_text
+    return [
+        (normalize_title(raw_title), anchor)
+        for _level, anchor, raw_title in HEADING_RE.findall(scope)
+    ]
+
+
+def titles_equal(a: str, b: str) -> bool:
+    return normalize_title(a) == normalize_title(b)
+
+
+def align_anchors_preorder(node: NavNode, headings: list[tuple[str, str]], index: int) -> int:
+    if index < len(headings) and titles_equal(node.title, headings[index][0]):
+        node.anchor = headings[index][1]
+        index += 1
+    for child in node.children:
+        index = align_anchors_preorder(child, headings, index)
+    return index
+
+
+def align_all_anchors(nav: MapNav, headings: list[tuple[str, str]]) -> None:
+    index = align_anchors_preorder(nav.root, headings, 0)
+    for nodes in nav.rhs_by_chunk.values():
+        for node in nodes:
+            index = align_anchors_preorder(node, headings, index)
+
+
+def render_toc_list(nodes: list[NavNode], depth: int = 1) -> str:
+    if not nodes:
+        return ''
+    cls = 'sectlevel1' if depth == 1 else f'sectlevel{depth}'
+    parts = [f'<ul class="{cls}">']
+    for node in nodes:
+        has_children = bool(node.children)
+        li_attrs = ' class="toc-collapsible expanded"' if has_children else ''
+        parts.append(f'<li{li_attrs}>')
+        if has_children:
+            parts.append(
+                '<button type="button" class="toc-chevron" '
+                'aria-label="Collapse section" aria-expanded="true"></button>'
+            )
+        href = f'#{html.escape(node.anchor)}' if node.anchor else '#'
+        parts.append(f'<a href="{href}">{html.escape(node.title)}</a>')
+        if has_children:
+            parts.append(render_toc_list(node.children, depth + 1))
+        parts.append('</li>')
+    parts.append('</ul>')
+    return ''.join(parts)
+
+
+def node_to_json(node: NavNode) -> dict:
+    return {
+        'title': node.title,
+        'anchor': node.anchor,
+        'children': [node_to_json(c) for c in node.children],
+    }
+
+
+def nav_to_json(nav: MapNav) -> str:
+    payload = {
+        'lhs': [node_to_json(c) for c in nav.root.children],
+        'rhsByChunk': {
+            key: [node_to_json(n) for n in nodes]
+            for key, nodes in nav.rhs_by_chunk.items()
+        },
+        'chunkAnchors': list(nav.rhs_by_chunk.keys()),
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def render_initial_rhs(nav: MapNav) -> str:
+    if not nav.rhs_by_chunk:
+        return ''
+    first_key = next(iter(nav.rhs_by_chunk))
+    nodes = nav.rhs_by_chunk[first_key]
+    inner = render_toc_list(nodes, 1).replace('class="sectlevel1"', 'class="rhs-list"')
+    return (
+        '<aside id="right-toc" aria-label="On this page">'
+        '<div class="right-toc-title">On this page</div>'
+        f'{inner}'
+        '</aside>'
+    )
+
+
+def inject_map_nav(html_path: pathlib.Path, master: pathlib.Path) -> None:
+    text = html_path.read_text(encoding='utf-8')
+    nav = build_map_nav(master.resolve())
+    headings = extract_html_headings(text)
+    align_all_anchors(nav, headings)
+
+    toc_inner = (
+        '<div id="toctitle">Navigation</div>\n'
+        '<div class="map-nav-note">JTBD preview — map LHS + chunk RHS</div>\n'
+        + render_toc_list(nav.root.children or [nav.root])
+    )
+
+    json_script = (
+        f'<script type="application/json" id="map-nav-data">'
+        f'{nav_to_json(nav)}</script>\n'
+    )
+
+    if re.search(r'<div id="toc" class="toc2">', text):
+        text = re.sub(
+            r'(<div id="toc" class="toc2">)(.*?)(</div>\s*</div>\s*<div id="content">)',
+            lambda m: m.group(1) + toc_inner + m.group(3),
+            text,
+            count=1,
+            flags=re.DOTALL,
+        )
+    else:
+        raise SystemExit(f'No #toc in {html_path}')
+
+    rhs_html = render_initial_rhs(nav)
+    if rhs_html and 'id="right-toc"' not in text:
+        text = text.replace('</body>', rhs_html + '\n</body>', 1)
+
+    if 'map-nav.js' not in text:
+        text = text.replace(
+            '</head>',
+            '<script src="/assets/js/map-nav.js" defer></script>\n</head>',
+            1,
+        )
+
+    text = text.replace('</head>', json_script + '</head>', 1)
+    text = re.sub(
+        r'<body class="([^"]*)"',
+        lambda m: f'<body class="{m.group(1)} has-right-toc map-nav-preview"',
+        text,
+        count=1,
+    )
+
+    html_path.write_text(text, encoding='utf-8')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Inject JTBD map LHS/RHS nav into preview HTML.')
+    parser.add_argument('html', type=pathlib.Path)
+    parser.add_argument('master', type=pathlib.Path)
+    args = parser.parse_args()
+    inject_map_nav(args.html.resolve(), args.master.resolve())
+    print(f'map nav (LHS+RHS): {args.html}')
+
+
+if __name__ == '__main__':
+    main()

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -299,24 +299,7 @@ def build_map_nav(master: pathlib.Path) -> MapNav:
     root = NavNode(title=title, anchor=anchor, leveloffset=0, source=master)
     rhs_by_chunk: dict[str, list[NavNode]] = {}
     _expand_nav(root, master, attrs, rhs_by_chunk, chunk_anchor=None, visited=set())
-    for chunk_key, nodes in list(rhs_by_chunk.items()):
-        attach_subsections_list(nodes, attrs)
     return MapNav(root=root, rhs_by_chunk=rhs_by_chunk)
-
-
-def attach_subsections_list(nodes: list[NavNode], attrs: dict[str, str] | None) -> None:
-    for node in nodes:
-        attach_subsections(node, attrs)
-
-
-def attach_subsections(node: NavNode, attrs: dict[str, str] | None = None) -> None:
-    if node.source and node.source.suffix == '.adoc':
-        has_subs = any(c.leveloffset == 0 for c in node.children)
-        if not has_subs:
-            for sub in subsection_nodes(node.source, attrs):
-                node.children.append(sub)
-    for child in node.children:
-        attach_subsections(child, attrs)
 
 
 def _expand_nav(

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -3,7 +3,7 @@
 JTBD map navigation for Surge preview (LHS + RHS).
 
 LHS: map entries staged by leveloffset (+1..+4), excluding toc="no" under a chunk.
-RHS: assembly L1 modules (collapsible); L2/==/=== nested under each L1 in JSON.
+RHS: in-page detail not already on the LHS — ==/=== subs and toc="no" modules.
 """
 
 from __future__ import annotations
@@ -218,9 +218,41 @@ def build_rhs_node(node: NavNode, attrs: dict[str, str]) -> NavNode:
     return clone_node(node, children=children)
 
 
+def lhs_visible_anchors(full_tree: list[NavNode]) -> set[str]:
+    return {node.anchor for node in strip_toc_no(full_tree) if node.anchor}
+
+
+def omit_lhs_modules(roots: list[NavNode], lhs_anchors: set[str]) -> list[NavNode]:
+    """Replace LHS-visible assembly modules with their in-page children on the RHS."""
+    result: list[NavNode] = []
+    for root in roots:
+        if root.anchor in lhs_anchors:
+            result.extend(root.children)
+        else:
+            result.append(root)
+    return result
+
+
 def build_rhs_for_chunk(full_tree: list[NavNode], attrs: dict[str, str]) -> list[NavNode]:
-    """Assembly L1 modules as RHS roots; L2 includes and ==/=== nested under their L1 parent."""
-    return [build_rhs_node(node, attrs) for node in full_tree]
+    """Build RHS roots: skip LHS-visible modules; promote toc_no-only wrappers."""
+    lhs_anchors = lhs_visible_anchors(full_tree)
+    roots = [build_rhs_node(node, attrs) for node in full_tree]
+    roots = omit_lhs_modules(roots, lhs_anchors)
+    return promote_rhs_roots(roots)
+
+
+def promote_rhs_roots(roots: list[NavNode]) -> list[NavNode]:
+    """When one L1 wrapper only groups toc_no modules (no == subs), use those modules as RHS roots."""
+    if len(roots) != 1:
+        return roots
+    wrapper = roots[0]
+    if not wrapper.children:
+        return roots
+    if any(not child.source for child in wrapper.children):
+        return roots
+    if not all(child.toc_no for child in wrapper.children):
+        return roots
+    return wrapper.children
 
 
 def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -3,7 +3,7 @@
 JTBD map navigation for Surge preview (LHS + RHS).
 
 LHS: map entries staged by leveloffset (+1..+4), excluding toc="no" under a chunk.
-RHS: toc="no" entries nested under :chunk-to-content: jobs, plus == subsections.
+RHS: assembly L1 modules (collapsible); L2/==/=== nested under each L1 in JSON.
 """
 
 from __future__ import annotations
@@ -434,7 +434,7 @@ def inject_map_nav(html_path: pathlib.Path, master: pathlib.Path) -> None:
 
     toc_inner = (
         '<div id="toctitle">Navigation</div>\n'
-        '<div class="map-nav-note">JTBD preview — map LHS + chunk RHS</div>\n'
+        '<div class="map-nav-note">JTBD preview — map LHS + assembly RHS</div>\n'
         + render_toc_list(nav.root.children or [nav.root])
     )
 

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -207,29 +207,29 @@ def strip_toc_no(nodes: list[NavNode]) -> list[NavNode]:
     return result
 
 
-def extract_toc_no_children(children: list[NavNode]) -> list[NavNode]:
-    extracted: list[NavNode] = []
-    for node in children:
-        if node.toc_no:
-            extracted.append(clone_node(node, children=extract_toc_no_children(node.children)))
-        else:
-            extracted.extend(extract_toc_no_children(node.children))
-    return extracted
-
-
-def build_rhs_roots(full_tree: list[NavNode]) -> list[NavNode]:
-    roots: list[NavNode] = []
-    for node in full_tree:
-        if node.toc_no:
-            continue
-        toc_children = extract_toc_no_children(node.children)
-        if toc_children:
-            roots.append(clone_node(node, children=toc_children))
-            continue
-        for child in node.children:
-            if not child.toc_no:
-                roots.extend(build_rhs_roots([child]))
-    return roots
+def build_rhs_sections(
+    path: pathlib.Path,
+    attrs: dict[str, str],
+    all_includes: list[NavNode],
+) -> list[NavNode]:
+    """One RHS entry per chunk section; children are only == subsections in that file."""
+    chunk_title, chunk_anchor = file_title_and_block_id(path, attrs)
+    sections = [
+        NavNode(
+            title=chunk_title,
+            anchor=chunk_anchor,
+            leveloffset=0,
+            source=path,
+            children=[],
+        )
+    ]
+    for node in all_includes:
+        subs = [
+            NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
+            for sub in subsection_nodes(node.source, attrs)
+        ]
+        sections.append(clone_node(node, children=subs))
+    return sections
 
 
 def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:
@@ -269,25 +269,7 @@ def build_map_nav(master: pathlib.Path) -> MapNav:
     root = NavNode(title=title, anchor=anchor, leveloffset=0, source=master)
     rhs_by_chunk: dict[str, list[NavNode]] = {}
     _expand_nav(root, master, attrs, rhs_by_chunk, chunk_anchor=None, visited=set())
-    attach_subsections(root, attrs)
-    for chunk_key, nodes in list(rhs_by_chunk.items()):
-        attach_subsections_list(nodes, attrs)
     return MapNav(root=root, rhs_by_chunk=rhs_by_chunk)
-
-
-def attach_subsections_list(nodes: list[NavNode], attrs: dict[str, str] | None) -> None:
-    for node in nodes:
-        attach_subsections(node, attrs)
-
-
-def attach_subsections(node: NavNode, attrs: dict[str, str] | None = None) -> None:
-    if node.source and node.source.suffix == '.adoc':
-        has_subs = any(c.leveloffset == 0 for c in node.children)
-        if not has_subs:
-            for sub in subsection_nodes(node.source, attrs):
-                node.children.append(sub)
-    for child in node.children:
-        attach_subsections(child, attrs)
 
 
 def _expand_nav(
@@ -322,12 +304,9 @@ def _expand_nav(
     full_tree = nest_by_leveloffset(all_includes)
     lhs_parent.children.extend(strip_toc_no(full_tree))
 
-    if chunk_anchor:
-        rhs_roots = build_rhs_roots(full_tree)
-        if rhs_roots:
-            existing = rhs_by_chunk.get(chunk_anchor, [])
-            existing.extend(rhs_roots)
-            rhs_by_chunk[chunk_anchor] = existing
+    if is_chunk_file(path):
+        _, chunk_key = file_title_and_block_id(path, attrs)
+        rhs_by_chunk[chunk_key] = build_rhs_sections(path, attrs, all_includes)
 
     for child in lhs_parent.children:
         if not child.source:
@@ -417,7 +396,7 @@ def node_to_json(node: NavNode) -> dict:
 def nav_to_json(nav: MapNav) -> str:
     payload = {
         'lhs': [node_to_json(c) for c in nav.root.children],
-        'rhsByChunk': {
+        'rhsSectionsByChunk': {
             key: [node_to_json(n) for n in nodes]
             for key, nodes in nav.rhs_by_chunk.items()
         },
@@ -426,16 +405,11 @@ def nav_to_json(nav: MapNav) -> str:
     return json.dumps(payload, ensure_ascii=False)
 
 
-def render_initial_rhs(nav: MapNav) -> str:
-    if not nav.rhs_by_chunk:
-        return ''
-    first_key = next(iter(nav.rhs_by_chunk))
-    nodes = nav.rhs_by_chunk[first_key]
-    inner = render_toc_list(nodes, 1, expanded=False).replace('class="sectlevel1"', 'class="rhs-list"')
+def render_initial_rhs() -> str:
     return (
         '<aside id="right-toc" aria-label="On this page">'
         '<div class="right-toc-title">On this page</div>'
-        f'{inner}'
+        '<p class="right-toc-empty">Scroll to a section</p>'
         '</aside>'
     )
 
@@ -468,8 +442,8 @@ def inject_map_nav(html_path: pathlib.Path, master: pathlib.Path) -> None:
     else:
         raise SystemExit(f'No #toc in {html_path}')
 
-    rhs_html = render_initial_rhs(nav)
-    if rhs_html and 'id="right-toc"' not in text:
+    rhs_html = render_initial_rhs()
+    if 'id="right-toc"' not in text:
         text = text.replace('</body>', rhs_html + '\n</body>', 1)
 
     if 'map-nav.js' not in text:

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -187,6 +187,51 @@ def nest_by_leveloffset(flat: list[NavNode]) -> list[NavNode]:
     return root.children
 
 
+def clone_node(node: NavNode, *, children: list[NavNode] | None = None) -> NavNode:
+    return NavNode(
+        title=node.title,
+        anchor=node.anchor,
+        leveloffset=node.leveloffset,
+        source=node.source,
+        toc_no=node.toc_no,
+        children=list(children if children is not None else node.children),
+    )
+
+
+def strip_toc_no(nodes: list[NavNode]) -> list[NavNode]:
+    result: list[NavNode] = []
+    for node in nodes:
+        if node.toc_no:
+            continue
+        result.append(clone_node(node, children=strip_toc_no(node.children)))
+    return result
+
+
+def extract_toc_no_children(children: list[NavNode]) -> list[NavNode]:
+    extracted: list[NavNode] = []
+    for node in children:
+        if node.toc_no:
+            extracted.append(clone_node(node, children=extract_toc_no_children(node.children)))
+        else:
+            extracted.extend(extract_toc_no_children(node.children))
+    return extracted
+
+
+def build_rhs_roots(full_tree: list[NavNode]) -> list[NavNode]:
+    roots: list[NavNode] = []
+    for node in full_tree:
+        if node.toc_no:
+            continue
+        toc_children = extract_toc_no_children(node.children)
+        if toc_children:
+            roots.append(clone_node(node, children=toc_children))
+            continue
+        for child in node.children:
+            if not child.toc_no:
+                roots.extend(build_rhs_roots([child]))
+    return roots
+
+
 def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:
     nodes: list[NavNode] = []
     past_title = False
@@ -261,29 +306,28 @@ def _expand_nav(
     if is_chunk_file(path):
         _, chunk_anchor = file_title_and_block_id(path, attrs)
 
-    flat_lhs: list[NavNode] = []
-    flat_rhs: list[NavNode] = []
-
+    all_includes: list[NavNode] = []
     for inc_path, leveloffset, toc_no in collect_includes(path):
         title, anchor = file_title_and_block_id(inc_path, attrs)
-        node = NavNode(
-            title=title,
-            anchor=anchor,
-            leveloffset=leveloffset,
-            source=inc_path,
-            toc_no=toc_no,
+        all_includes.append(
+            NavNode(
+                title=title,
+                anchor=anchor,
+                leveloffset=leveloffset,
+                source=inc_path,
+                toc_no=toc_no,
+            )
         )
-        if chunk_anchor and toc_no:
-            flat_rhs.append(node)
-        else:
-            flat_lhs.append(node)
 
-    lhs_parent.children.extend(nest_by_leveloffset(flat_lhs))
+    full_tree = nest_by_leveloffset(all_includes)
+    lhs_parent.children.extend(strip_toc_no(full_tree))
 
-    if chunk_anchor and flat_rhs:
-        existing = rhs_by_chunk.get(chunk_anchor, [])
-        existing.extend(nest_by_leveloffset(flat_rhs))
-        rhs_by_chunk[chunk_anchor] = existing
+    if chunk_anchor:
+        rhs_roots = build_rhs_roots(full_tree)
+        if rhs_roots:
+            existing = rhs_by_chunk.get(chunk_anchor, [])
+            existing.extend(rhs_roots)
+            rhs_by_chunk[chunk_anchor] = existing
 
     for child in lhs_parent.children:
         if not child.source:

--- a/preview/map_nav.py
+++ b/preview/map_nav.py
@@ -207,29 +207,29 @@ def strip_toc_no(nodes: list[NavNode]) -> list[NavNode]:
     return result
 
 
-def build_rhs_sections(
-    path: pathlib.Path,
-    attrs: dict[str, str],
-    all_includes: list[NavNode],
-) -> list[NavNode]:
-    """One RHS entry per chunk section; children are only == subsections in that file."""
-    chunk_title, chunk_anchor = file_title_and_block_id(path, attrs)
-    sections = [
-        NavNode(
-            title=chunk_title,
-            anchor=chunk_anchor,
-            leveloffset=0,
-            source=path,
-            children=[],
-        )
-    ]
-    for node in all_includes:
-        subs = [
-            NavNode(title=sub.title, anchor=sub.anchor, leveloffset=0, source=node.source)
-            for sub in subsection_nodes(node.source, attrs)
-        ]
-        sections.append(clone_node(node, children=subs))
-    return sections
+def extract_toc_no_children(children: list[NavNode]) -> list[NavNode]:
+    extracted: list[NavNode] = []
+    for node in children:
+        if node.toc_no:
+            extracted.append(clone_node(node, children=extract_toc_no_children(node.children)))
+        else:
+            extracted.extend(extract_toc_no_children(node.children))
+    return extracted
+
+
+def build_rhs_roots(full_tree: list[NavNode]) -> list[NavNode]:
+    roots: list[NavNode] = []
+    for node in full_tree:
+        if node.toc_no:
+            continue
+        toc_children = extract_toc_no_children(node.children)
+        if toc_children:
+            roots.append(clone_node(node, children=toc_children))
+            continue
+        for child in node.children:
+            if not child.toc_no:
+                roots.extend(build_rhs_roots([child]))
+    return roots
 
 
 def subsection_nodes(path: pathlib.Path, attrs: dict[str, str] | None = None) -> list[NavNode]:
@@ -269,7 +269,25 @@ def build_map_nav(master: pathlib.Path) -> MapNav:
     root = NavNode(title=title, anchor=anchor, leveloffset=0, source=master)
     rhs_by_chunk: dict[str, list[NavNode]] = {}
     _expand_nav(root, master, attrs, rhs_by_chunk, chunk_anchor=None, visited=set())
+    attach_subsections(root, attrs)
+    for chunk_key, nodes in list(rhs_by_chunk.items()):
+        attach_subsections_list(nodes, attrs)
     return MapNav(root=root, rhs_by_chunk=rhs_by_chunk)
+
+
+def attach_subsections_list(nodes: list[NavNode], attrs: dict[str, str] | None) -> None:
+    for node in nodes:
+        attach_subsections(node, attrs)
+
+
+def attach_subsections(node: NavNode, attrs: dict[str, str] | None = None) -> None:
+    if node.source and node.source.suffix == '.adoc':
+        has_subs = any(c.leveloffset == 0 for c in node.children)
+        if not has_subs:
+            for sub in subsection_nodes(node.source, attrs):
+                node.children.append(sub)
+    for child in node.children:
+        attach_subsections(child, attrs)
 
 
 def _expand_nav(
@@ -304,9 +322,12 @@ def _expand_nav(
     full_tree = nest_by_leveloffset(all_includes)
     lhs_parent.children.extend(strip_toc_no(full_tree))
 
-    if is_chunk_file(path):
-        _, chunk_key = file_title_and_block_id(path, attrs)
-        rhs_by_chunk[chunk_key] = build_rhs_sections(path, attrs, all_includes)
+    if chunk_anchor:
+        rhs_roots = build_rhs_roots(full_tree)
+        if rhs_roots:
+            existing = rhs_by_chunk.get(chunk_anchor, [])
+            existing.extend(rhs_roots)
+            rhs_by_chunk[chunk_anchor] = existing
 
     for child in lhs_parent.children:
         if not child.source:
@@ -396,7 +417,7 @@ def node_to_json(node: NavNode) -> dict:
 def nav_to_json(nav: MapNav) -> str:
     payload = {
         'lhs': [node_to_json(c) for c in nav.root.children],
-        'rhsSectionsByChunk': {
+        'rhsByChunk': {
             key: [node_to_json(n) for n in nodes]
             for key, nodes in nav.rhs_by_chunk.items()
         },
@@ -405,11 +426,16 @@ def nav_to_json(nav: MapNav) -> str:
     return json.dumps(payload, ensure_ascii=False)
 
 
-def render_initial_rhs() -> str:
+def render_initial_rhs(nav: MapNav) -> str:
+    if not nav.rhs_by_chunk:
+        return ''
+    first_key = next(iter(nav.rhs_by_chunk))
+    nodes = nav.rhs_by_chunk[first_key]
+    inner = render_toc_list(nodes, 1, expanded=False).replace('class="sectlevel1"', 'class="rhs-list"')
     return (
         '<aside id="right-toc" aria-label="On this page">'
         '<div class="right-toc-title">On this page</div>'
-        '<p class="right-toc-empty">Scroll to a section</p>'
+        f'{inner}'
         '</aside>'
     )
 
@@ -442,8 +468,8 @@ def inject_map_nav(html_path: pathlib.Path, master: pathlib.Path) -> None:
     else:
         raise SystemExit(f'No #toc in {html_path}')
 
-    rhs_html = render_initial_rhs()
-    if 'id="right-toc"' not in text:
+    rhs_html = render_initial_rhs(nav)
+    if rhs_html and 'id="right-toc"' not in text:
         text = text.replace('</body>', rhs_html + '\n</body>', 1)
 
     if 'map-nav.js' not in text:

--- a/preview/surge-preview.css
+++ b/preview/surge-preview.css
@@ -195,6 +195,14 @@ body.article {
   display: block;
 }
 
+#right-toc li.rhs-collapsible li.rhs-collapsible > a.rhs-parent {
+  padding-left: 1rem;
+}
+
+#right-toc li.rhs-collapsible li.rhs-collapsible > .rhs-chevron {
+  left: 0;
+}
+
 @media only screen and (max-width: 1279px) {
   #right-toc {
     display: none;

--- a/preview/surge-preview.css
+++ b/preview/surge-preview.css
@@ -28,6 +28,16 @@ body.article {
   }
 }
 
+/* Map-driven TOC label (Release Notes / JTBD preview pilot) */
+#toc.toc2 .map-nav-note {
+  color: #666;
+  font-family: "Red Hat Text", Roboto, sans-serif;
+  font-size: 0.6875rem;
+  line-height: 1.3;
+  margin: 0.25rem 0 0.75rem;
+  padding: 0 0.5rem;
+}
+
 /* RH accent on links */
 #content a:hover,
 #toc a:hover {
@@ -81,4 +91,77 @@ body.article {
 #toc.toc2 ul.sectlevel3 li.toc-collapsible > a,
 #toc.toc2 ul.sectlevel4 li.toc-collapsible > a {
   padding-left: 1.25rem;
+}
+
+/* Right-hand "On this page" nav (chunked job sections) */
+body.has-right-toc #content {
+  margin-right: 16rem;
+}
+
+#right-toc {
+  background: #fafafa;
+  border-left: 1px solid #ddd;
+  box-sizing: border-box;
+  font-family: "Red Hat Text", Roboto, sans-serif;
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  overflow-y: auto;
+  padding: 1rem 0.75rem 2rem;
+  position: fixed;
+  right: 0;
+  top: 2rem;
+  width: 15rem;
+  height: calc(100% - 2rem);
+  z-index: 1000;
+}
+
+#right-toc .right-toc-title {
+  color: #333;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+#right-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#right-toc li {
+  margin: 0.15rem 0;
+}
+
+#right-toc a {
+  color: #0066cc;
+  display: block;
+  padding: 0.15rem 0;
+  text-decoration: none;
+}
+
+#right-toc a:hover,
+#right-toc a.active {
+  color: #ee0000;
+}
+
+#right-toc ul ul {
+  margin-left: 0.75rem;
+}
+
+#right-toc .right-toc-empty {
+  color: #666;
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+@media only screen and (max-width: 1279px) {
+  body.has-right-toc #content {
+    margin-right: 0;
+  }
+
+  #right-toc {
+    display: none;
+  }
 }

--- a/preview/surge-preview.css
+++ b/preview/surge-preview.css
@@ -93,11 +93,8 @@ body.article {
   padding-left: 1.25rem;
 }
 
-/* Right-hand "On this page" nav (chunked job sections) */
-body.has-right-toc #content {
-  margin-right: 16rem;
-}
-
+/* Right-hand "On this page" nav (chunked job sections).
+   Overlay the panel — do not shift #content; redhat.css already offsets for LHS. */
 #right-toc {
   background: #fafafa;
   border-left: 1px solid #ddd;
@@ -156,11 +153,49 @@ body.has-right-toc #content {
   margin: 0;
 }
 
-@media only screen and (max-width: 1279px) {
-  body.has-right-toc #content {
-    margin-right: 0;
-  }
+/* RHS: show level-2+ only when the level-1 parent is expanded */
+#right-toc li.rhs-collapsible {
+  position: relative;
+}
 
+#right-toc li.rhs-collapsible > .rhs-chevron {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 0.65rem;
+  left: 0;
+  line-height: 1.4;
+  padding: 0.15rem 0.25rem 0.15rem 0;
+  position: absolute;
+  top: 0.1rem;
+  width: 1rem;
+}
+
+#right-toc li.rhs-collapsible > .rhs-chevron::before {
+  content: '▸';
+  display: inline-block;
+}
+
+#right-toc li.rhs-collapsible.expanded > .rhs-chevron::before {
+  content: '▾';
+}
+
+#right-toc li.rhs-collapsible > a.rhs-parent {
+  display: block;
+  padding-left: 1rem;
+}
+
+#right-toc li.rhs-collapsible > ul {
+  display: none;
+  margin-left: 0.75rem;
+}
+
+#right-toc li.rhs-collapsible.expanded > ul {
+  display: block;
+}
+
+@media only screen and (max-width: 1279px) {
   #right-toc {
     display: none;
   }


### PR DESCRIPTION
## Summary
- Adds `preview/map_nav.py` to inject JTBD map-driven left-hand navigation and chunk-based right-hand "On this page" nav into Surge preview HTML builds
- Enables map nav for all `quay_jtbd/*/master.adoc` category books and the product navigation MAP (`quay-3-18-navigation.adoc`)
- Adds `preview/assets/js/map-nav.js` and RHS panel CSS so the right nav updates when scrolling between chunked jobs or clicking LHS links
- Updates Surge deploy PR comments to list all JTBD preview URLs when preview infrastructure files change

## Test plan
- [ ] Wait for Surge Preview Build + Deploy workflows to complete on this PR
- [ ] Open the bot comment URL and verify **What's new** (`/quay_jtbd-whats_new.html`):
  - LHS: Red Hat Quay Release Notes → RHSA-2026:48085
  - RHS: New features and nested `==` sections
- [ ] Spot-check **Plan** (`/quay_jtbd-plan.html`) and product nav (`/quay-3-18-navigation.html`) for LHS + RHS
- [ ] Confirm RHS panel hides below 1280px viewport width


Made with [Cursor](https://cursor.com)