### PR TITLE
Complete Secure job navtitles for left-hand navigation

### DIFF
--- a/quay_jtbd/secure/master.adoc
+++ b/quay_jtbd/secure/master.adoc
@@ -10,13 +10,13 @@ include::configure-ssl-tls-for-standalone-red-hat-quay.adoc[leveloffset=+1,navti
 include::configure-ssl-tls-for-quay-on-openshift.adoc[leveloffset=+1,navtitle="SSL/TLS on OpenShift"]
 
 // Job: Secure database connections with TLS
-include::secure-database-connections-with-tls.adoc[leveloffset=+1]
+include::secure-database-connections-with-tls.adoc[leveloffset=+1,navtitle="Database TLS"]
 
 // Job: Add trusted certificate authorities
-include::add-trusted-certificate-authorities.adoc[leveloffset=+1]
+include::add-trusted-certificate-authorities.adoc[leveloffset=+1,navtitle="Trusted CAs"]
 
 // Job: Authenticate users with LDAP
-include::authenticate-users-with-ldap.adoc[leveloffset=+1]
+include::authenticate-users-with-ldap.adoc[leveloffset=+1,navtitle="LDAP authentication"]
 
 // Job: Authenticate users with OIDC and single sign-on
 include::authenticate-users-with-oidc-and-single-sign-on.adoc[leveloffset=+1,navtitle="OIDC and SSO"]
@@ -28,10 +28,10 @@ include::eliminate-long-lived-robot-credentials-with-keyless-authentication.adoc
 include::ensure-fips-compliance-for-the-registry.adoc[leveloffset=+1,navtitle="FIPS compliance"]
 
 // Job: Set repository permissions and visibility
-include::set-repository-permissions-and-visibility.adoc[leveloffset=+1]
+include::set-repository-permissions-and-visibility.adoc[leveloffset=+1,navtitle="Repository permissions"]
 
 // Job: Manage registry-wide and team access policies
 include::manage-registry-wide-and-team-access-policies.adoc[leveloffset=+1,navtitle="Registry access policies"]
 
 // Job: Review Clair vulnerability scan results
-include::review-clair-vulnerability-scan-results.adoc[leveloffset=+1]
+include::review-clair-vulnerability-scan-results.adoc[leveloffset=+1,navtitle="Clair scan results"]


### PR DESCRIPTION
## Summary

- Adds `navtitle` to the five Secure jobs that were omitted in #1769 (short titles were left unchanged in that PR).
- Every job in `quay_jtbd/secure/master.adoc` now has a concise LHS label, matching the Configure, Migrate, and other JTBD category MAPs.

| Job | navtitle |
|-----|----------|
| Secure database connections with TLS | Database TLS |
| Add trusted certificate authorities | Trusted CAs |
| Authenticate users with LDAP | LDAP authentication |
| Set repository permissions and visibility | Repository permissions |
| Review Clair vulnerability scan results | Clair scan results |

## Test plan

- [ ] Run `./build_docs_preview` and open the Secure category in `quay-3-18-navigation.html`
- [ ] Confirm all 11 Secure jobs show short navtitles in the left-hand navigation
- [ ] Confirm page titles in content are unchanged (navtitle affects MAP navigation only)


Made with [Cursor](https://cursor.com)