### PR TITLE
fix(quay-docs):Remove commented-out 3.0-master downstream section from README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,49 +163,6 @@ Never use the `--force` argument when pushing to `master`.
 $ git push --force origin <feature_branch>
 ----
 
-ifdef::downstream[]
-
-////
-[id="how-do-i-keep-the-downstream-repository-and-branch-up-to-date"]
-== How do I keep the downstream repository and branch up-to-date?
-
-To bring the https://gitlab.cee.redhat.com/red-hat-quay-documentation/quay-documentation/[downstream repository] up-to-date with the upstream repository, you need to push the changes to the `3.0-master` branch of the downstream repository and merge `3.0-master` into `3.0-stage`, from which downstream documentation is published:
-
-. Update your local `3.0-master` branch. <<how-do-i-keep-my-local-3.0-master-up-to-date-with-remote-3.0-master>>
-
-. Switch to the `3.0-master` branch:
-+
-----
-$ git checkout 3.0-master
-----
-
-. Push `3.0-master` to the downstream repository:
-+
-----
-$ git push downstream
-----
-
-. Switch to the `3.0-stage` branch:
-+
-----
-$ git checkout 3.0-stage
-----
-
-. Merge `3.0-master` into `3.0-stage`:
-+
-----
-$ git merge 3.0-master
-----
-
-. Push `3.0-stage` to the downstream repository:
-+
-----
-$ git push downstream
-----
-
-endif::downstream[]
-////
-
 == How do I make content appear in upstream but not in downstream?
 
 You can make content appear only in the upstream by using the `ifdef::upstream` conditional around the content that you only want to appear upstream. For example: 


### PR DESCRIPTION
Issue: cleaning up the commented-out 3.0-master section in quay-docs/README.adoc

It would be a good cleanup to remove the commented-out 3.0-master section entirely (lines 168–207), since it describes a deprecated workflow and could cause confusion for anyone reading the raw source file (as it did here). A small PR to strip that dead block would keep things tidy.

I have removed the commented out section since it describes a deprecated workflow and could cause confusion for anyone.

Reported Issue: https://github.com/quay/quay-docs/issues/812

Opened: PROJQUAY-12816