### PR TITLE
Backport #1777: Fix DEFAULT_SYSTEM_REJECT_QUOTA_BYTES docs (redhat-3.14)

### DIFF
--- a/modules/config-fields-quota-management.adoc
+++ b/modules/config-fields-quota-management.adoc
@@ -12,7 +12,7 @@ The following configuration fields enable and customize quota management functio
 
 **Default:** `False`
 
-| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | String | Enables system default quota reject byte allowance for all organizations. 
+| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | Integer | Enables system default quota reject byte allowance for all organizations. 
 
 By default, no limit is set.
 
@@ -38,7 +38,7 @@ By default, no limit is set.
 ----
 # ...
 FEATURE_QUOTA_MANAGEMENT: true
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: "100gb"
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 QUOTA_BACKFILL: true
 QUOTA_TOTAL_DELAY_SECONDS: "3600"
 PERMANENTLY_DELETE_TAGS: true

--- a/modules/setting-default-quota.adoc
+++ b/modules/setting-default-quota.adoc
@@ -15,7 +15,7 @@ The following procedure shows you how to configure a system-wide default quota.
 [source,yaml]
 ----
 # ...
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 100gb
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 # ...
 ----
 


### PR DESCRIPTION
## Summary
- Backports [quay/quay-docs#1777](https://github.com/quay/quay-docs/pull/1777) to `redhat-3.14`
- Documents `DEFAULT_SYSTEM_REJECT_QUOTA_BYTES` as an **Integer** (bytes), not a human-readable string like `"100gb"`
- Updates example values to `107374182400` (100 GiB in bytes)
- Resolves [PROJQUAY-12811](https://issues.redhat.com/browse/PROJQUAY-12811)

## Test plan
- [ ] Verify `modules/config-fields-quota-management.adoc` shows type Integer and byte example
- [ ] Verify `modules/setting-default-quota.adoc` example uses `107374182400`

Made with [Cursor](https://cursor.com)