### PR TITLE
fix(quay-docs): Update clair container version projquay 12895

### DIFF
--- a/modules/accessing-images.adoc
+++ b/modules/accessing-images.adoc
@@ -12,7 +12,7 @@ To access {productname} and Clair images for standalone upgrades, pull from regi
 
 * **Quay:** {productrepo}/{quayimage}:{productminv}
 ifdef::downstream[]
-* **Clair:** {productrepo}/{clairimage}:{productminv}
+* **Clair:** {productrepo}/{clairimage}:{clairproductminv}
 endif::downstream[]
 ifdef::upstream[]
 * **Clair:** {productrepo}/{clairimage}:{clairproductminv}
@@ -26,7 +26,7 @@ endif::upstream[]
 
 * **Quay:** {productrepo}/{quayimage}:{productminv}
 ifdef::downstream[]
-* **Clair:** {productrepo}/{clairimage}:{productminv}
+* **Clair:** {productrepo}/{clairimage}:{clairproductminv}
 endif::downstream[]
 ifdef::upstream[]
 * **Clair:** {productrepo}/{clairimage}:{clairproductminv}
@@ -40,7 +40,7 @@ endif::upstream[]
 
 * **Quay:** {productrepo}/{quayimage}:{productminv}
 ifdef::downstream[]
-* **Clair:** {productrepo}/{clairimage}:{productminv}
+* **Clair:** {productrepo}/{clairimage}:{clairproductminv}
 endif::downstream[]
 ifdef::upstream[]
 * **Clair:** {productrepo}/{clairimage}:{clairproductminv}

--- a/modules/clair-postgresql-database-update.adoc
+++ b/modules/clair-postgresql-database-update.adoc
@@ -97,5 +97,5 @@ $ sudo podman run -d --name clairv4 \
 -p 8081:8081 -p 8088:8088 \
 -e CLAIR_CONF=/clair/config.yaml \
 -e CLAIR_MODE=combo \
-registry.redhat.io/quay/clair-rhel8:{productminv}
+registry.redhat.io/quay/clair-rhel8:{clairproductminv}
 ----

--- a/modules/clair-standalone-config-location.adoc
+++ b/modules/clair-standalone-config-location.adoc
@@ -44,5 +44,5 @@ $ sudo podman run -it --rm --name clairv4 \
 -e CLAIR_CONF=/clair/config.yaml \
 -e CLAIR_MODE=combo \
 -v /etc/clairv4/config:/clair:Z \
-{productrepo}/{clairimage}:{productminv}
+{productrepo}/{clairimage}:{clairproductminv}
 ----

--- a/modules/clair-standalone-configure.adoc
+++ b/modules/clair-standalone-configure.adoc
@@ -149,7 +149,7 @@ $ sudo podman run -d --name clairv4 \
 -e CLAIR_CONF=/clair/config.yaml \
 -e CLAIR_MODE=combo \
 -v /etc/opt/clairv4/config:/clair:Z \
-{productrepo}/{clairimage}:{productminv}
+{productrepo}/{clairimage}:{clairproductminv}
 ----
 +
 [NOTE]


### PR DESCRIPTION
Issue: Wrong version for Clair container  #503 [PROJQUAY-12895]

Solution:

 All Clair image references now use the dedicated {clairproductminv} attribute instead of the shared {productminv} (Quay) version.

Root cause: Clair and Quay ship on different version tracks, but several docs tagged the Clair image with {productminv} (the Quay version). So Clair rendered with Quay's tag instead of its own.

~~~
modules/accessing-images.adoc — the 3 downstream Clair entries (lines 15, 29, 43); the upstream ones already used {clairproductminv}
modules/clair-postgresql-database-update.adoc:100
modules/clair-standalone-config-location.adoc:47
modules/clair-standalone-configure.adoc:152
~~~