### PR TITLE
Reframe Develop jobs as customer outcomes

### DIFF
--- a/quay_jtbd/develop/automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="automate-organization-and-quota-operations-through-the-red-hat-quay-api_{context}"]
-= Automate organization and quota operations through the Red Hat Quay API
+= Script organization, quota, and mirroring from the API
 :context: automate_organization_and_quota_operations_through_the_red_hat_quay_api
 
 [role="_abstract"]
-Automate organization management, quota limits, mirroring, and global messages by using the Red Hat Quay API. Organization procedures cover contact email, members, applications, and proxy cache configuration.
+To script {productname} tenancy without the UI, you can use API examples for organizations, quota, mirroring, and global messages. You can then manage many organizations from automation.
 
 include::modules/managing-user-options-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: automate_organization_and_quota_operations_through_the_red_hat_quay_api
 
 [role="_abstract"]
-To script {productname} tenancy without the UI, you can use API examples for organizations, quota, mirroring, and global messages. You can then manage many organizations from automation.
+Automate organization management, quota limits, mirroring, and global messages by using the Red Hat Quay API. Organization procedures cover contact email, members, applications, and proxy cache configuration.
 
 include::modules/managing-user-options-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="automate-repository-and-robot-operations-through-the-red-hat-quay-api_{context}"]
-= Automate repository and robot operations through the Red Hat Quay API
+= Script repositories, permissions, and robots from the API
 :context: automate_repository_and_robot_operations_through_the_red_hat_quay_api
 
 [role="_abstract"]
-Automate repository permissions, auto-prune policies, and robot operations by using the Red Hat Quay API.
+To script {productname} repository setup without the UI, you can use API examples for repository permissions, auto-prune policies, and robot operations.
 
 include::modules/repo-permission-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: automate_repository_and_robot_operations_through_the_red_hat_quay_api
 
 [role="_abstract"]
-To script {productname} repository setup without the UI, you can use API examples for repository permissions, auto-prune policies, and robot operations.
+Automate repository permissions, auto-prune policies, and robot operations by using the Red Hat Quay API.
 
 include::modules/repo-permission-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="automate-tags-teams-and-builds-through-the-red-hat-quay-api_{context}"]
-= Automate tags and teams through the Red Hat Quay API
+= Script tags, teams, and search from the API
 :context: automate_tags_teams_and_builds_through_the_red_hat_quay_api
 
 [role="_abstract"]
-Automate tag management, team operations, and registry search by using the Red Hat Quay API.
+To script {productname} tags and team membership without the UI, you can use API examples for tags, teams, and registry search.
 
 include::modules/search-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: automate_tags_teams_and_builds_through_the_red_hat_quay_api
 
 [role="_abstract"]
-To script {productname} tags and team membership without the UI, you can use API examples for tags, teams, and registry search.
+Automate tag management, team operations, and registry search by using the Red Hat Quay API.
 
 include::modules/search-api.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/build-container-images-from-dockerfiles-in-red-hat-quay.adoc
+++ b/quay_jtbd/develop/build-container-images-from-dockerfiles-in-red-hat-quay.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="build-container-images-from-dockerfiles-in-red-hat-quay_{context}"]
-= Build container images from Dockerfiles in Red Hat Quay
+= Build images from Dockerfiles in Quay
 :context: build_container_images_from_dockerfiles_in_red_hat_quay
 
 [role="_abstract"]
-Build container images from Dockerfiles by using the Red Hat Quay UI or API, including starting builds and creating build triggers.
+To produce {productname} images from Dockerfiles, you can start builds from the UI or API. The registry then holds the artifacts your pipeline needs.
 
 include::modules/builds-overview.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/build-container-images-from-dockerfiles-in-red-hat-quay.adoc
+++ b/quay_jtbd/develop/build-container-images-from-dockerfiles-in-red-hat-quay.adoc
@@ -5,7 +5,7 @@
 :context: build_container_images_from_dockerfiles_in_red_hat_quay
 
 [role="_abstract"]
-To produce {productname} images from Dockerfiles, you can start builds from the UI or API. The registry then holds the artifacts your pipeline needs.
+Build container images from Dockerfiles by using the Red Hat Quay UI or API, including starting builds and creating build triggers.
 
 include::modules/builds-overview.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/configure-build-triggers-for-red-hat-quay.adoc
+++ b/quay_jtbd/develop/configure-build-triggers-for-red-hat-quay.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="configure-build-triggers-for-red-hat-quay_{context}"]
-= Configure build triggers for Red Hat Quay
+= Start builds automatically from Git
 :context: configure_build_triggers_for_red_hat_quay
 
 [role="_abstract"]
-Configure Git, webhook, and GitHub App build triggers, including credentials, SSH keys, and manual build starts.
+To start {productname} builds from source control, you can configure Git, webhook, and GitHub App triggers. Images then build automatically on commit.
 
 include::modules/proc_use-quay-git-trigger.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/configure-build-triggers-for-red-hat-quay.adoc
+++ b/quay_jtbd/develop/configure-build-triggers-for-red-hat-quay.adoc
@@ -5,7 +5,7 @@
 :context: configure_build_triggers_for_red_hat_quay
 
 [role="_abstract"]
-To start {productname} builds from source control, you can configure Git, webhook, and GitHub App triggers. Images then build automatically on commit.
+Configure Git, webhook, and GitHub App build triggers, including credentials, SSH keys, and manual build starts.
 
 include::modules/proc_use-quay-git-trigger.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/get-started-with-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/get-started-with-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="get-started-with-the-red-hat-quay-api_{context}"]
-= Get started with the Red Hat Quay API
+= Get your first API workflow running
 :context: get_started_with_the_red_hat_quay_api
 
 [role="_abstract"]
-Learn how OAuth 2.0 tokens work, enable the Red Hat Quay API, and use API endpoints, Swagger, and automation workflows. Before you call authenticated endpoints, create an OAuth 2 access token; see "Manage OAuth access tokens for the Red Hat Quay API".
+To get your first {productname} API workflow running, you can enable the API, explore Swagger, and handle common errors. Before you call authenticated endpoints, create an OAuth 2 access token.
 
 include::modules/token-overview.adoc[leveloffset=+1]
 
@@ -24,7 +24,7 @@ include::modules/quay-error-details.adoc[leveloffset=+2,toc="no"]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:manage-oauth-access-tokens-for-the-red-hat-quay-api[Manage OAuth access tokens for the Red Hat Quay API]
+* xref:manage-oauth-access-tokens-for-the-red-hat-quay-api[Authenticate applications with OAuth access tokens]
 * xref:oauth2-access-tokens[About OAuth 2 access tokens]
 * xref:creating-oauth-access-token[Creating an OAuth 2 access token]
 * xref:creating-oauth-application-api[Managing a user application by using the API]

--- a/quay_jtbd/develop/get-started-with-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/get-started-with-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: get_started_with_the_red_hat_quay_api
 
 [role="_abstract"]
-To get your first {productname} API workflow running, you can enable the API, explore Swagger, and handle common errors. Before you call authenticated endpoints, create an OAuth 2 access token.
+Learn how OAuth 2.0 tokens work, enable the Red Hat Quay API, and use API endpoints, Swagger, and automation workflows. Before you call authenticated endpoints, create an OAuth 2 access token; see "Manage OAuth access tokens for the Red Hat Quay API".
 
 include::modules/token-overview.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="manage-oauth-access-tokens-for-the-red-hat-quay-api_{context}"]
-= Manage OAuth access tokens for the Red Hat Quay API
+= Authenticate applications with OAuth access tokens
 :context: manage_oauth_access_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-Review OAuth 2 access token scopes and security, then create, reassign, revoke, and rotate organization OAuth 2 access tokens. After you have an OAuth 2 access token, you can create user application tokens for Docker, Podman, and other clients.
+To keep long-lived {productname} API integrations under control, you can create, reassign, revoke, and rotate OAuth 2 access tokens. Applications can then authenticate day to day with tokens you can revoke or rotate.
 
 include::modules/oauth2-access-tokens.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: manage_oauth_access_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-To keep long-lived {productname} API integrations under control, you can create, reassign, revoke, and rotate OAuth 2 access tokens. Applications can then authenticate day to day with tokens you can revoke or rotate.
+Review OAuth 2 access token scopes and security, then create, reassign, revoke, and rotate organization OAuth 2 access tokens. After you have an OAuth 2 access token, you can create user application tokens for Docker, Podman, and other clients.
 
 include::modules/oauth2-access-tokens.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api_{context}"]
-= Manage OCI referrers OAuth access tokens for the Red Hat Quay API
+= List OCI referrers with a dedicated token
 :context: manage_oci_referrers_oauth_access_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-Create OCI referrers OAuth access tokens to list OCI referrers of a manifest under a repository by using the {productname} `v2/auth` endpoint.
+To list OCI referrers of a {productname} manifest, you can create an OCI referrers OAuth token from the `v2/auth` endpoint. You can then query referrers without using a general OAuth access token.
 
 include::modules/oci-referrers-oauth-access-token.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: manage_oci_referrers_oauth_access_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-To list OCI referrers of a {productname} manifest, you can create an OCI referrers OAuth token from the `v2/auth` endpoint. You can then query referrers without using a general OAuth access token.
+Create OCI referrers OAuth access tokens to list OCI referrers of a manifest under a repository by using the {productname} `v2/auth` endpoint.
 
 include::modules/oci-referrers-oauth-access-token.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-robot-account-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-robot-account-tokens-for-the-red-hat-quay-api.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="manage-robot-account-tokens-for-the-red-hat-quay-api_{context}"]
-= Manage robot account tokens for the Red Hat Quay API
+= Authenticate CI/CD with robot account tokens
 :context: manage_robot_account_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-Create and regenerate robot account tokens for CI/CD pull and push access without interactive user authentication.
+To let CI/CD pull and push {productname} images without a human login, you can create and regenerate robot account tokens. Pipelines can then authenticate without interactive user credentials.
 
 include::modules/robot-account-tokens.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/manage-robot-account-tokens-for-the-red-hat-quay-api.adoc
+++ b/quay_jtbd/develop/manage-robot-account-tokens-for-the-red-hat-quay-api.adoc
@@ -5,7 +5,7 @@
 :context: manage_robot_account_tokens_for_the_red_hat_quay_api
 
 [role="_abstract"]
-To let CI/CD pull and push {productname} images without a human login, you can create and regenerate robot account tokens. Pipelines can then authenticate without interactive user credentials.
+Create and regenerate robot account tokens for CI/CD pull and push access without interactive user authentication.
 
 include::modules/robot-account-tokens.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/master.adoc
+++ b/quay_jtbd/develop/master.adoc
@@ -3,32 +3,32 @@ include::_attributes/attributes.adoc[]
 = Develop
 
 
-// Job: Get started with the Red Hat Quay API
-include::get-started-with-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Get started with the API"]
+// Job: Get your first API workflow running
+include::get-started-with-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="First API workflow"]
 
-// Job: Manage OAuth access tokens for the Red Hat Quay API
+// Job: Authenticate applications with OAuth access tokens
 include::manage-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="OAuth access tokens"]
 
-// Job: Manage robot account tokens for the Red Hat Quay API
+// Job: Authenticate CI/CD with robot account tokens
 include::manage-robot-account-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Robot account tokens"]
 
-// Job: Manage OCI referrers OAuth access tokens for the Red Hat Quay API
+// Job: List OCI referrers with a dedicated token
 include::manage-oci-referrers-oauth-access-tokens-for-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="OCI referrers tokens"]
 
-// Job: Automate organization and quota operations through the Red Hat Quay API
-include::automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Organization and quota automation"]
+// Job: Script organization, quota, and mirroring from the API
+include::automate-organization-and-quota-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Script orgs and quota"]
 
-// Job: Automate repository and robot operations through the Red Hat Quay API
-include::automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Repository and robot automation"]
+// Job: Script repositories, permissions, and robots from the API
+include::automate-repository-and-robot-operations-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Script repos and robots"]
 
-// Job: Automate tags and teams through the Red Hat Quay API
-include::automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Tags, teams, and builds"]
+// Job: Script tags, teams, and search from the API
+include::automate-tags-teams-and-builds-through-the-red-hat-quay-api.adoc[leveloffset=+1,navtitle="Script tags and teams"]
 
-// Job: Build container images from Dockerfiles in Red Hat Quay
+// Job: Build images from Dockerfiles in Quay
 include::build-container-images-from-dockerfiles-in-red-hat-quay.adoc[leveloffset=+1,navtitle="Build from Dockerfiles"]
 
-// Job: Configure build triggers for Red Hat Quay
-include::configure-build-triggers-for-red-hat-quay.adoc[leveloffset=+1,navtitle="Build triggers"]
+// Job: Start builds automatically from Git
+include::configure-build-triggers-for-red-hat-quay.adoc[leveloffset=+1,navtitle="Build from Git"]
 
-// Job: Work with OCI artifacts, Helm charts, and image signing
-include::work-with-oci-artifacts-helm-charts-and-image-signing.adoc[leveloffset=+1,navtitle="OCI artifacts and signing"]
+// Job: Push Helm charts, OCI artifacts, and signed images
+include::work-with-oci-artifacts-helm-charts-and-image-signing.adoc[leveloffset=+1,navtitle="Helm, OCI, and signing"]

--- a/quay_jtbd/develop/work-with-oci-artifacts-helm-charts-and-image-signing.adoc
+++ b/quay_jtbd/develop/work-with-oci-artifacts-helm-charts-and-image-signing.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="work-with-oci-artifacts-helm-charts-and-image-signing_{context}"]
-= Work with OCI artifacts, Helm charts, and image signing
+= Push Helm charts, OCI artifacts, and signed images
 :context: work_with_oci_artifacts_helm_charts_and_image_signing
 
 [role="_abstract"]
-Push OCI artifacts and Helm charts, attach referrers to image tags, and sign content with Cosign in Red Hat Quay.
+To store artifacts beyond container images in {productname}, you can push OCI artifacts and Helm charts and sign content with Cosign. The registry then holds signed, non-image content.
 
 include::modules/oci-intro.adoc[leveloffset=+1]
 

--- a/quay_jtbd/develop/work-with-oci-artifacts-helm-charts-and-image-signing.adoc
+++ b/quay_jtbd/develop/work-with-oci-artifacts-helm-charts-and-image-signing.adoc
@@ -5,7 +5,7 @@
 :context: work_with_oci_artifacts_helm_charts_and_image_signing
 
 [role="_abstract"]
-To store artifacts beyond container images in {productname}, you can push OCI artifacts and Helm charts and sign content with Cosign. The registry then holds signed, non-image content.
+Push OCI artifacts and Helm charts, attach referrers to image tags, and sign content with Cosign in Red Hat Quay.
 
 include::modules/oci-intro.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Rewrite Develop assembly titles and left-nav labels as customer outcomes (for example, **Get your first API workflow running**, **Authenticate applications with OAuth access tokens**).
- Assembly abstracts are the original short descriptions, not the rewritten `To…, you can…` versions. IDs and filenames are unchanged.

## Test plan
- [ ] Scan the Develop left nav and confirm job labels match the new outcome titles
- [ ] Open each job and confirm the H1 matches the new title
- [ ] Confirm abstracts still read as the original short descriptions (not first-person *To…, you can…*)