### PR TITLE
Rename Integrate Job 2 to plan and enable image mirroring

### DIFF
--- a/quay_jtbd/integrate/master.adoc
+++ b/quay_jtbd/integrate/master.adoc
@@ -6,8 +6,8 @@ include::_attributes/attributes.adoc[]
 // Job: Connect OpenShift to Quay with the Quay Bridge Operator
 include::connect-openshift-to-quay-with-the-quay-bridge-operator.adoc[leveloffset=+1,navtitle="Quay Bridge Operator"]
 
-// Job: Plan and enable repository mirroring
-include::plan-and-enable-repository-mirroring.adoc[leveloffset=+1,navtitle="Repository mirroring"]
+// Job: Plan and enable image mirroring
+include::plan-and-enable-repository-mirroring.adoc[leveloffset=+1,navtitle="Image mirroring"]
 
 // Job: Create mirrors and monitor synchronization
 include::create-mirrors-and-monitor-synchronization.adoc[leveloffset=+1,navtitle="Mirrors and synchronization"]

--- a/quay_jtbd/integrate/plan-and-enable-repository-mirroring.adoc
+++ b/quay_jtbd/integrate/plan-and-enable-repository-mirroring.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 :chunk-to-content:
 [id="plan_and_enable_repository_mirroring_{context}"]
-= Plan and enable repository mirroring
+= Plan and enable image mirroring
 :context: plan_and_enable_repository_mirroring
 
 [role="_abstract"]
-Review repository mirroring concepts, enable repository and organization mirroring in configuration, and create a mirroring worker for standalone deployments.
+To bring upstream images into {productname}, you can review mirroring concepts and enable repository and organization mirroring. You can then create mirrors after mirroring is turned on.
 
 include::modules/mirroring-intro.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Rename Integrate Job 2 from **Plan and enable repository mirroring** to **Plan and enable image mirroring**, with left-nav **Image mirroring**, so the title covers both repository and organization mirroring (Tony’s Integrate comment).
- Rewrite the assembly abstract from the ranking job statement. IDs, filenames, and `:context:` stay `plan_and_enable_repository_mirroring`.
- Proxy cache (Job 4) is unchanged; it remains the UI/manual path.

## Test plan
- [ ] On the Surge preview, confirm Integrate left nav shows **Image mirroring** (not Repository mirroring)
- [ ] Open Job 2 and confirm the H1 is **Plan and enable image mirroring**
- [ ] Confirm organization mirroring modules are still under that job
- [ ] Confirm Job 3 (create and monitor) and Job 4 (proxy cache) titles are unchanged
- [ ] Spot-check the abstract for first-person language (`I`, `my`)


Made with [Cursor](https://cursor.com)