### PR TITLE
Use GET when resolving fork PRs for Surge deploy

### DIFF
--- a/.github/workflows/surge-preview-deploy.yaml
+++ b/.github/workflows/surge-preview-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
             echo "Invalid head branch for PR lookup" >&2
             exit 1
           fi
-          PR_NUMBER="$(gh api \
+          PR_NUMBER="$(gh api --method GET \
             -H 'Accept: application/vnd.github+json' \
             -f state=open \
             -f head="${HEAD_OWNER}:${HEAD_BRANCH}" \


### PR DESCRIPTION
## Summary
- #1794’s fork fallback still failed on #1793: `gh api -f` against `/repos/{owner}/{repo}/pulls` sends **POST** (create PR) and 422s with `"base" wasn't supplied`.
- Pass `--method GET` so the call lists the unique open PR for the trusted `head=owner:branch`.

## Test plan
- [ ] Merge to `master`
- [ ] Re-run or push #1793 and confirm **Surge Preview Deploy** gets past Resolve PR number
- [ ] Confirm the bot comment updates off `ecda3c6` and `npx surge` runs (rotated `SURGE_TOKEN` check)


Made with [Cursor](https://cursor.com)