### PR TITLE
fix(quay-docs):Adding changes to Addmaximum_chunk_size_gbStorage branch

### DIFF
--- a/modules/config-fields-ibmcloudstorage.adoc
+++ b/modules/config-fields-ibmcloudstorage.adoc
@@ -19,6 +19,7 @@ DISTRIBUTED_STORAGE_CONFIG:
     port: '443'
     storage_path: /datastorage/registry
     maximum_chunk_size_mb: 100mb
+    maximum_chunk_size_gb: 5gb
     minimum_chunk_size_mb: 5mb
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
 - default
@@ -29,6 +30,7 @@ DISTRIBUTED_STORAGE_PREFERENCE:
 where:
 
 `DISTRIBUTED_STORAGE_CONFIG.default.maximum_chunk_size_mb`:: Specifies the maximum chunk size. Recommended to be set to `100mb`. This field is optional.
+`DISTRIBUTED_STORAGE_CONFIG.default.maximum_chunk_size_gb`:: Specifies the maximum chunk size, in GB. Defaults to `5gb`. This field is optional.
 `DISTRIBUTED_STORAGE_CONFIG.default.minimum_chunk_size_mb`:: Specifies defaults to `5mb`. Do not adjust this field without consulting Red Hat Support in Additional resources, because it can have unintended consequences. This field is optional.
 
 [role="_additional-resources"]

--- a/modules/config-fields-storage-noobaa.adoc
+++ b/modules/config-fields-storage-noobaa.adoc
@@ -20,10 +20,12 @@ DISTRIBUTED_STORAGE_CONFIG:
       port: '443'
       storage_path: /datastorage/registry
       maximum_chunk_size_mb: 100
+      maximum_chunk_size_gb: 5
       server_side_assembly: true
 ----
 
 where:
 
 `DISTRIBUTED_STORAGE_CONFIG.rhocsStorage.maximum_chunk_size_mb`:: Specifies the maximum chunk size, in MB, for the final copy. Has no effect if `server_side_assembly` is set to `False`.
+`DISTRIBUTED_STORAGE_CONFIG.rhocsStorage.maximum_chunk_size_gb`:: Specifies the maximum chunk size, in GB, for the final copy. Defaults to `5`. Has no effect if `server_side_assembly` is set to `False`. This field is optional.
 `DISTRIBUTED_STORAGE_CONFIG.rhocsStorage.server_side_assembly`:: Specifies whether {productname} tries to use server-side assembly and the final chunked copy instead of client assembly. Defaults to `True`. This field is optional.

--- a/modules/config-fields-storage-rados.adoc
+++ b/modules/config-fields-storage-rados.adoc
@@ -26,6 +26,7 @@ DISTRIBUTED_STORAGE_CONFIG:
       secret_key: <secret_key_here>
       storage_path: /datastorage/registry
       maximum_chunk_size_mb: 100
+      maximum_chunk_size_gb: 5
       server_side_assembly: true
 ----
 
@@ -33,6 +34,7 @@ where:
 
 `DISTRIBUTED_STORAGE_CONFIG.radosGWStorage`:: Specifies general S3 access. Note that general S3 access is not strictly limited to Amazon Web Services (AWS) S3, and can be used with RadosGW or other storage services. For an example of general S3 access using the AWS S3 driver, see "AWS S3 storage".
 `DISTRIBUTED_STORAGE_CONFIG.radosGWStorage.maximum_chunk_size_mb`:: Specifies the maximum chunk size in MB for the final copy. Has no effect if `server_side_assembly` is set to `False`. This field is optional.
+`DISTRIBUTED_STORAGE_CONFIG.radosGWStorage.maximum_chunk_size_gb`:: Specifies the maximum chunk size in GB for the final copy. Defaults to `5`. Has no effect if `server_side_assembly` is set to `False`. This field is optional.
 `DISTRIBUTED_STORAGE_CONFIG.radosGWStorage.server_side_assembly`:: Specifies whether {productname} tries to use server-side assembly and the final chunked copy instead of client assembly. Defaults to `True`. This field is optional.
 
 [role="_additional-resources"]


### PR DESCRIPTION
[Issue] This (maximum_chunk_size_gb) value controls the per-part size for S3 multipart uploads, and AWS S3 enforces a hard
    limit of 5 GB per part. Setting it higher than 5 will cause S3 to reject the upload parts entityTooLarge).

chunk_size = maximum_chunk_size_gb if maximum_chunk_size_gb is not None else 5  # 5gb default

The issue is that the maximum_chunk_size_gb value is not currently documented in the Quay documentation, while the maximum_chunk_size_mb setting is already included in the referenced documentation.

The solution is to include maximum_chunk_size_gb in the referenced documentation to provide a more comprehensive description of the feature and improve the overall product documentation.

[Doc] https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html/configure_red_hat_quay/config-fields-required-intro#config-fields-storage-noobaa