### PR TITLE
Fix duplicate rows in health check endpoints table

### DIFF
--- a/modules/config-fields-health-check.adoc
+++ b/modules/config-fields-health-check.adoc
@@ -2,23 +2,23 @@
 [id="config-fields-health-check"]
 = Storage health check configuration fields
 
+[role="_abstract"]
 The following configuration fields control how {productname} validates storage engine availability during health checks. These fields allow you to tune the `GET /health/instance` and `GET /health/endtoend` endpoints for geo-replicated deployments and Kubernetes liveness probes.
 
 .Storage health check configuration fields
 [cols="3a,1a,2a",options="header"]
 |===
 | Field | Type | Description
-| **HEALTH_CHECKER_INSTANCE_CHECK_PREFERRED_STORAGE** +
-(Optional) | Boolean | When set to `true`, the `/health/instance` endpoint includes a `preferred_storage` check that validates the first preferred storage engine. The endpoint returns `503` if the preferred storage is unavailable, which causes Kubernetes to remove the pod from load balancing. Automatically skipped when the registry is in readonly mode. +
- +
+| **HEALTH_CHECKER_INSTANCE_CHECK_PREFERRED_STORAGE** (Optional) | Boolean | When set to `true`, the `/health/instance` endpoint includes a `preferred_storage` check that validates the first preferred storage engine. The endpoint returns `503` if the preferred storage is unavailable, which causes Kubernetes to remove the pod from load balancing. Automatically skipped when the registry is in readonly mode. 
+
 **Default:** `False`
-| **DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND** +
-(Optional) | Boolean | When set to `true`, the `/health/endtoend` endpoint validates *all* configured storage engines instead of only the preferred engine. Recommended for geo-replicated environments to detect partial storage failures across sites. See also `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE`. +
- +
+
+| **DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND** (Optional) | Boolean | When set to `true`, the `/health/endtoend` endpoint validates *all* configured storage engines instead of only the preferred engine. Recommended for geo-replicated environments to detect partial storage failures across sites. See also `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE`. 
+
 **Default:** `False`
-| **DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE** +
-(Optional) | Boolean | When set to `true`, the `/health/endtoend` health check returns `503` if any single storage engine is unavailable. When `false`, `503` is returned only if all storage engines fail simultaneously, allowing the registry to remain operational during partial outages. Only takes effect when `DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND` is `true`. +
- +
+
+| **DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE** (Optional) | Boolean | When set to `true`, the `/health/endtoend` health check returns `503` if any single storage engine is unavailable. When `false`, `503` is returned only if all storage engines fail simultaneously, allowing the registry to remain operational during partial outages. Only takes effect when `DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND` is `true`.
+
 **Default:** `False`
 |===
 

--- a/modules/health-check-quay.adoc
+++ b/modules/health-check-quay.adoc
@@ -41,9 +41,7 @@ Preferred storage unavailable:
 
 |`endtoend` |The `endtoend` endpoint conducts checks on all services of your {productname} instance. Returns a `dict` with key-value pairs for the following: `auth`, `database`, `redis`, `storage`. Returns a number indicating the health check response of either `200`, which indicates that the instance is healthy, or `503`, which indicates an issue with your deployment.
 
-By default, only the preferred storage engine is validated. When `DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND` is set to `true`, all configured storage engines are checked. With `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE: false` (default), `503` is returned only when all storage engines fail simultaneously; a partial failure returns `200`. With `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE: true`, `503` is returned if any single storage engine is unavailable.
-
-Superusers and sessions with `health_debug` enabled receive an expanded `services_expanded` field in the response body that includes per-service failure details.
+By default, only the preferred storage engine is validated. When `DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND` is set to `true`, all configured storage engines are checked. With `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE: false` (default), `503` is returned only when all storage engines fail simultaneously; a partial failure returns `200`. With `DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE: true`, `503` is returned if any single storage engine is unavailable. The storage check is automatically skipped when the registry is in readonly mode.
 |`https://{quay-ip-endpoint}/health/endtoend`
 a|All services healthy:
 [source,json]
@@ -80,7 +78,8 @@ Storage engine unavailable (superuser view with `DISTRIBUTED_STORAGE_VALIDATE_EN
 |`warning` |The `warning` endpoint conducts a check on the warnings. Returns a `dict` with key-value pairs for the following: `disk_space_warning`. Returns a number indicating the health check response of either `200`, which indicates that the instance is healthy, or `503`, which indicates an issue with your deployment.
 |`https://{quay-ip-endpoint}/health/warning` | `{"data":{"services":{"disk_space_warning":true}},"status_code":503}`
 |===
-|`instance` | The `instance` endpoint acquires the entire status of the specific {productname} instance. Returns a `dict` with key-value pairs for the following: `auth`, `database`, `disk_space`, `registry_gunicorn`, `service_key`, and `web_gunicorn.` Returns a number indicating the health check response of either `200`, which indicates that the instance is healthy, or `503`, which indicates an issue with your deployment. |`/health/instance` or `/health` on your {productname} instance | `{"data":{"services":{"auth":true,"database":true,"disk_space":true,"registry_gunicorn":true,"service_key":true,"web_gunicorn":true}},"status_code":200}`
-|`endtoend` |The `endtoend` endpoint conducts checks on all services of your {productname} instance. Returns a `dict` with key-value pairs for the following: `auth`, `database`, `redis`, `storage`. Returns a number indicating the health check response of either `200`, which indicates that the instance is healthy, or `503`, which indicates an issue with your deployment. |`/health/endtoend` on your {productname} instance | `{"data":{"services":{"auth":true,"database":true,"redis":true,"storage":true}},"status_code":200}`
-|`warning` |The `warning` endpoint conducts a check on the warnings. Returns a `dict` with key-value pairs for the following: `disk_space_warning`. Returns a number indicating the health check response of either `200`, which indicates that the instance is healthy, or `503`, which indicates an issue with your deployment. |`/health/warning` on your {productname} instance | `{"data":{"services":{"disk_space_warning":true}},"status_code":503}`
-|===
+
+[NOTE]
+====
+Superusers and sessions with `health_debug` enabled receive a `services_expanded` field in health check responses that includes per-service failure details.
+====


### PR DESCRIPTION
Remove orphaned table rows left after merging #1667, document readonly mode for endtoend storage checks, and move services_expanded guidance into a note that applies to all health check responses.