### PR TITLE
Adds 3.15.8 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.15
-:productminv: v3.15.7
+:productminv: v3.15.8
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -34,8 +34,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productversion: 3
 :producty: 3.15
 :producty-n1: 3.14
-:productmin: 3.15.7
-:productminv: v3.15.7
+:productmin: 3.15.8
+:productminv: v3.15.8
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn-3-15-8.adoc
+++ b/modules/rn-3-15-8.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: REFERENCE
+[id="rn-3-15-8"]
+= RHSA-2026:63307 - {productname} 3.15.8 release
+
+Issued 2026-09-03
+
+[role="_abstract"]
+{productname} release 3.15.8 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:63307[RHSA-2026:63307] advisory.
+

--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -33,6 +33,7 @@ endif::downstream[]
 
 
 include::modules/rn_overview.adoc[leveloffset=+1]
+include::modules/rn-3-15-8.adoc[leveloffset=+2]
 include::modules/rn-3-15-7.adoc[leveloffset=+2]
 include::modules/rn-3-15-6.adoc[leveloffset=+2]
 include::modules/rn-3-15-4.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.15.8
- Source: https://github.com/quay/quay-konflux-configs/pull/291
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-13155

## Skipped (not documented)
All eleven fixed issues are CVE-only (PROJQUAY-12736, PROJQUAY-12585, PROJQUAY-12584, PROJQUAY-12571, PROJQUAY-12514, PROJQUAY-12478, PROJQUAY-12472, PROJQUAY-12462, PROJQUAY-12431, PROJQUAY-12359, PROJQUAY-12218). Advisory-only entry per 3.15 y-stream convention.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (RHSA-2026:63307, issued 2026-09-03)
- [ ] Attributes updated to 3.15.8
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.15


Made with [Cursor](https://cursor.com)