### PR TITLE
Adds 3.9.26 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -15,7 +15,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.9
-:productminv: v3.9.25
+:productminv: v3.9.26
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -31,8 +31,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.9
-:productmin: 3.9.25
-:productminv: v3.9.25
+:productmin: 3.9.26
+:productminv: v3.9.26
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_90.adoc
+++ b/modules/rn_3_90.adoc
@@ -7,11 +7,11 @@ The following sections detail _y_ and _z_ stream release information.
 
 
 [id="rn-3-9026"]
-== RHSA-TBD - {productname} 3.9.26 release
+== RHSA-2026:65514 - {productname} 3.9.26 release
 
 Issued 2026-09-08
 
-{productname} release 3.9.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory.
+{productname} release 3.9.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:65514[RHSA-2026:65514] advisory.
 
 [id="rn-3-9025"]
 == RHSA-2026:50931 - {productname} 3.9.25 release

--- a/modules/rn_3_90.adoc
+++ b/modules/rn_3_90.adoc
@@ -6,6 +6,13 @@
 The following sections detail _y_ and _z_ stream release information.
 
 
+[id="rn-3-9026"]
+== RHSA-TBD - {productname} 3.9.26 release
+
+Issued 2026-09-08
+
+{productname} release 3.9.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory.
+
 [id="rn-3-9025"]
 == RHSA-2026:50931 - {productname} 3.9.25 release
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.9.26
- Source: https://github.com/quay/quay-konflux-configs/pull/290
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-13156

## Skipped (not documented)
All twenty-four fixed issues are CVE-only. Advisory-only entry per 3.9 y-stream convention.

## Manual follow-up before merge
- **Errata not yet published** on access.redhat.com as of 2026-09-08. Replace `RHSA-TBD` and the errata link in `modules/rn_3_90.adoc` with the real advisory ID and confirm the issued date when RHSA is live.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (update from RHSA-TBD)
- [ ] Attributes updated to 3.9.26
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.9


Made with [Cursor](https://cursor.com)