### PR TITLE
Fix builders book Pantheon unknown-ID xref errors

### DIFF
--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -14,7 +14,7 @@ To configure virtual builds for {productname-ocp} with {productname}, you can cr
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have configured the {ocp} TLS component for builds.
 * You are logged into {ocp} as a cluster administrator.
 

--- a/modules/builds-overview.adoc
+++ b/modules/builds-overview.adoc
@@ -17,4 +17,4 @@ Running builds directly in a container on bare metal does not provide the same i
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-discover.adoc#arch-intro-build-automation[Build automation architecture guide]
+* xref:arch-intro-build-automation.adoc#arch-intro-build-automation[Build automation architecture guide]

--- a/modules/configuring-openshift-tls-component-builds.adoc
+++ b/modules/configuring-openshift-tls-component-builds.adoc
@@ -11,7 +11,7 @@ When setting the `tls` component to `unmanaged`, you must supply your own `ssl.c
 
 .Prerequisites
 
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 
 .Procedure
 

--- a/modules/prepare-ocp-for-bare-metal-builds.adoc
+++ b/modules/prepare-ocp-for-bare-metal-builds.adoc
@@ -13,7 +13,7 @@ If you are using the {productname} Operator on {ocp} with a managed `route` comp
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You are logged into {ocp} as a cluster administrator.
 
 .Procedure 

--- a/modules/red-hat-quay-builders-ui.adoc
+++ b/modules/red-hat-quay-builders-ui.adoc
@@ -23,7 +23,7 @@ The following steps can be replicated to create a _build trigger_ using Github, 
 ifeval::["{context}" == "quay-builders-image-automation"]
 .Prerequisites
 
-* For {productname-ocp} deployments, you have configured your {ocp} environment for either xref:quay_jtbd-configure.adoc#bare-metal-builds[bare metal builds] or xref:quay_jtbd-configure.adoc#red-hat-quay-builders-enhancement[virtual builds]. 
+* For {productname-ocp} deployments, you have configured your {ocp} environment for either xref:bare-metal-builds[bare metal builds] or xref:red-hat-quay-builders-enhancement[virtual builds]. 
 endif::[]
 
 .Procedure 


### PR DESCRIPTION
## Summary
- Replace JTBD book-MAP xrefs (`quay_jtbd-*.adoc#id`) in builders modules with paths to the module files that actually define those IDs, so Pantheon does not treat them as missing in-book anchors.
- Use ID-only xrefs for `bare-metal-builds` and `red-hat-quay-builders-enhancement`, which are already included in this assembly.

## Test plan
- [ ] Rebuild *Builders and image automation* on Pantheon and confirm the unknown ID errors for `arch-intro-build-automation` and `ssl-tls-quay-overview` are gone.
- [ ] Confirm the architecture and SSL/TLS prerequisite links still point at the intended topics.
- [ ] Confirm the build-trigger prerequisites still jump to bare metal and virtual builds in this book.


Made with [Cursor](https://cursor.com)