### PR TITLE
Use published links for builders cross-book Pantheon refs

### DIFF
--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -14,7 +14,7 @@ To configure virtual builds for {productname-ocp} with {productname}, you can cr
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have configured the {ocp} TLS component for builds.
 * You are logged into {ocp} as a cluster administrator.
 

--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -14,7 +14,7 @@ To configure virtual builds for {productname-ocp} with {productname}, you can cr
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have configured the {ocp} TLS component for builds.
 * You are logged into {ocp} as a cluster administrator.
 

--- a/modules/builds-overview.adoc
+++ b/modules/builds-overview.adoc
@@ -17,4 +17,4 @@ Running builds directly in a container on bare metal does not provide the same i
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_architecture/index#arch-intro-build-automation[Build automation architecture guide]
+* xref:../../architecture/master.adoc#arch-intro-build-automation[Build automation architecture guide]

--- a/modules/builds-overview.adoc
+++ b/modules/builds-overview.adoc
@@ -17,4 +17,4 @@ Running builds directly in a container on bare metal does not provide the same i
 [role="_additional-resources"]
 .Additional resources
 
-* xref:arch-intro-build-automation.adoc#arch-intro-build-automation[Build automation architecture guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_architecture/index#arch-intro-build-automation[Build automation architecture guide]

--- a/modules/configuring-openshift-tls-component-builds.adoc
+++ b/modules/configuring-openshift-tls-component-builds.adoc
@@ -11,7 +11,7 @@ When setting the `tls` component to `unmanaged`, you must supply your own `ssl.c
 
 .Prerequisites
 
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 
 .Procedure
 

--- a/modules/configuring-openshift-tls-component-builds.adoc
+++ b/modules/configuring-openshift-tls-component-builds.adoc
@@ -11,7 +11,7 @@ When setting the `tls` component to `unmanaged`, you must supply your own `ssl.c
 
 .Prerequisites
 
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 
 .Procedure
 

--- a/modules/prepare-ocp-for-bare-metal-builds.adoc
+++ b/modules/prepare-ocp-for-bare-metal-builds.adoc
@@ -13,7 +13,7 @@ If you are using the {productname} Operator on {ocp} with a managed `route` comp
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:ssl-tls-quay-overview.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You are logged into {ocp} as a cluster administrator.
 
 .Procedure 

--- a/modules/prepare-ocp-for-bare-metal-builds.adoc
+++ b/modules/prepare-ocp-for-bare-metal-builds.adoc
@@ -13,7 +13,7 @@ If you are using the {productname} Operator on {ocp} with a managed `route` comp
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You are logged into {ocp} as a cluster administrator.
 
 .Procedure 


### PR DESCRIPTION
## Summary
- Replace the remaining builders cross-book `xref`s with `link:` URLs to the published Architecture and Securing titles.
- Pantheon treats xrefs to sibling files in this book's `modules/` directory as in-book IDs. Those modules are not included in this assembly, so `arch-intro-build-automation` and `ssl-tls-quay-overview` fail as unknown internal IDs.
- Keep ID-only xrefs for bare metal and virtual builds, which are already in this book.

## Test plan
- [ ] Rebuild *Builders and image automation* on Pantheon and confirm the unknown-ID errors are gone.
- [ ] Confirm the architecture and SSL/TLS prerequisite links open the published topics.


Made with [Cursor](https://cursor.com)