### PR TITLE
Use links for builders cross-book refs; keep in-book xrefs

### DIFF
--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -14,7 +14,7 @@ To configure virtual builds for {productname-ocp} with {productname}, you can cr
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have configured the {ocp} TLS component for builds.
 * You are logged into {ocp} as a cluster administrator.
 

--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -14,7 +14,7 @@ To configure virtual builds for {productname-ocp} with {productname}, you can cr
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have configured the {ocp} TLS component for builds.
 * You are logged into {ocp} as a cluster administrator.
 

--- a/modules/builds-overview.adoc
+++ b/modules/builds-overview.adoc
@@ -17,4 +17,4 @@ Running builds directly in a container on bare metal does not provide the same i
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_architecture/index#arch-intro-build-automation[Build automation architecture guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index#arch-intro-build-automation[Build automation architecture guide]

--- a/modules/builds-overview.adoc
+++ b/modules/builds-overview.adoc
@@ -17,4 +17,4 @@ Running builds directly in a container on bare metal does not provide the same i
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../architecture/master.adoc#arch-intro-build-automation[Build automation architecture guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_architecture/index#arch-intro-build-automation[Build automation architecture guide]

--- a/modules/configuring-openshift-tls-component-builds.adoc
+++ b/modules/configuring-openshift-tls-component-builds.adoc
@@ -11,7 +11,7 @@ When setting the `tls` component to `unmanaged`, you must supply your own `ssl.c
 
 .Prerequisites
 
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 
 .Procedure
 

--- a/modules/configuring-openshift-tls-component-builds.adoc
+++ b/modules/configuring-openshift-tls-component-builds.adoc
@@ -11,7 +11,7 @@ When setting the `tls` component to `unmanaged`, you must supply your own `ssl.c
 
 .Prerequisites
 
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 
 .Procedure
 

--- a/modules/prepare-ocp-for-bare-metal-builds.adoc
+++ b/modules/prepare-ocp-for-bare-metal-builds.adoc
@@ -13,7 +13,7 @@ If you are using the {productname} Operator on {ocp} with a managed `route` comp
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see xref:../../securing_quay/master.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You are logged into {ocp} as a cluster administrator.
 
 .Procedure 

--- a/modules/prepare-ocp-for-bare-metal-builds.adoc
+++ b/modules/prepare-ocp-for-bare-metal-builds.adoc
@@ -13,7 +13,7 @@ If you are using the {productname} Operator on {ocp} with a managed `route` comp
 .Prerequisites 
 
 * You have an {ocp} cluster provisioned with the {productname} Operator running.
-* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
+* You have set the `tls` component to `unmanaged` and uploaded custom SSL/TLS certificates to the {productname} Operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You are logged into {ocp} as a cluster administrator.
 
 .Procedure 


### PR DESCRIPTION
## Summary
- Keep `xref:` only for targets included in this book's `master.adoc` (bare metal and virtual builds).
- Use published `link:` URLs for Architecture and Securing topics, which live in other titles. Relative `xref:../../` paths failed on Pantheon the same way as JTBD book xrefs.

## Test plan
- [ ] Rebuild *Builders and image automation* on Pantheon and confirm there are no unknown-ID xref errors.
- [ ] Confirm the architecture and SSL/TLS links open the published topics.
- [ ] Confirm build-trigger prerequisites still jump to bare metal and virtual builds in this book.


Made with [Cursor](https://cursor.com)