### PR TITLE
Convert remaining legacy books' out-of-book xrefs to 3.18 links

### DIFF
--- a/modules/about-clair.adoc
+++ b/modules/about-clair.adoc
@@ -152,13 +152,13 @@ endif::[]
 .Additional resources
 
 ifeval::["{context}" == "security-scanning"]
-* xref:quay_jtbd-configure.adoc[Vulnerability reporting with Clair on {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index[Vulnerability reporting with Clair on {productname}]
 endif::[]
 
 ifeval::["{context}" == "clair"]
 * link:https://github.com/quay/clair/releases[Clair releases]
 * link:https://github.com/quay/clair/releases/tag/v4.9.0[Clair 4.9.0 release]
-* xref:quay_jtbd-upgrade.adoc#upgrading-clair-postgresql-database[Migrating the Clair PostgreSQL database from version 13 to 15]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#upgrading-clair-postgresql-database[Migrating the Clair PostgreSQL database from version 13 to 15]
 * link:https://github.com/quay/clair/blob/release-4.7/Documentation/howto/deployment.md#disk-usage-considerations[Disk usage considerations]
 * link:https://osv.dev/[OSV.dev]
 * link:https://catalog.redhat.com[Red Hat Ecosystem Catalog]

--- a/modules/adding-a-new-tag-to-image-api.adoc
+++ b/modules/adding-a-new-tag-to-image-api.adoc
@@ -7,11 +7,11 @@ To add a new tag or restore an older tag on an image in {productname}, you can u
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. You can change which image a tag points to or create a new tag by using the xref:quay_jtbd-reference.adoc#changetag[`PUT /api/v1/repository/{repository}/tag/{tag}`] command:
+. You can change which image a tag points to or create a new tag by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#changetag[`PUT /api/v1/repository/{repository}/tag/{tag}`] command:
 +
 [source,terminal]
 ----
@@ -30,7 +30,7 @@ $ curl -X PUT \
 "Updated"
 ----
 
-. You can restore a repository tag to its previous image by using the xref:quay_jtbd-reference.adoc#restoretag[`POST /api/v1/repository/{repository}/tag/{tag}/restore`] command. For example:
+. You can restore a repository tag to its previous image by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#restoretag[`POST /api/v1/repository/{repository}/tag/{tag}/restore`] command. For example:
 +
 [source,terminal]
 ----
@@ -49,7 +49,7 @@ $ curl -X POST \
 {}
 ----
 
-. To see a list of tags after creating a new tag you can use the xref:quay_jtbd-reference.adoc#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
+. To see a list of tags after creating a new tag you can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
 +
 [source,terminal]
 ----

--- a/modules/adjust-access-user-repo-api.adoc
+++ b/modules/adjust-access-user-repo-api.adoc
@@ -14,11 +14,11 @@ To change or remove access for a user or robot account on a repository, you can 
 .Prerequisites
 
 * You have created a user account or robot account.
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following xref:quay_jtbd-reference.adoc#changeuserpermissions[`PUT /api/v1/repository/{repository}/permissions/user/{username}`] command to change the permissions of a user:
+. Enter the following link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#changeuserpermissions[`PUT /api/v1/repository/{repository}/permissions/user/{username}`] command to change the permissions of a user:
 +
 [source,terminal]
 ----
@@ -35,7 +35,7 @@ $ curl -X PUT \
 {"role": "admin", "name": "quayadmin+test", "is_robot": true, "avatar": {"name": "quayadmin+test", "hash": "ca9afae0a9d3ca322fc8a7a866e8476dd6c98de543decd186ae090e420a88feb", "color": "#8c564b", "kind": "robot"}}
 ----
 
-. To delete the current permission, you can enter the xref:quay_jtbd-reference.adoc#deleteuserpermissions[`DELETE /api/v1/repository/{repository}/permissions/user/{username}`] command:
+. To delete the current permission, you can enter the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#deleteuserpermissions[`DELETE /api/v1/repository/{repository}/permissions/user/{username}`] command:
 +
 [source,terminal]
 ----
@@ -45,7 +45,7 @@ $ curl -X DELETE \
   https://<quay-server.example.com>/api/v1/repository/<namespace>/<repository>/permissions/user/<username>
 ----
 +
-This command does not return any output in the CLI. Instead, you can confirm deletion by entering the xref:quay_jtbd-reference.adoc#listrepouserpermissions[`GET /api/v1/repository/{repository}/permissions/user/`] command:
+This command does not return any output in the CLI. Instead, you can confirm deletion by entering the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepouserpermissions[`GET /api/v1/repository/{repository}/permissions/user/`] command:
 +
 [source,terminal]
 ----

--- a/modules/adjusting-repository-access-via-the-api.adoc
+++ b/modules/adjusting-repository-access-via-the-api.adoc
@@ -10,11 +10,11 @@
 [role="_abstract"]
 To control who can pull or interact with a repository, you can set its visibility to public or private by using the {productname} API.
 
-The visibility of your repository can be set to `private` or `public` by using the xref:quay_jtbd-reference.adoc#changerepovisibility[`POST /api/v1/repository/{repository}/changevisibility`] command.
+The visibility of your repository can be set to `private` or `public` by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#changerepovisibility[`POST /api/v1/repository/{repository}/changevisibility`] command.
 
 .Prerequisites 
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 * You have created a repository. 
 
 .Procedure

--- a/modules/api-mirror-getRepositoryMirrorHealth.adoc
+++ b/modules/api-mirror-getRepositoryMirrorHealth.adoc
@@ -104,4 +104,4 @@ Substitute an OAuth access token that includes the `super:user` scope for global
 }
 ----
 
-For metric names, example Prometheus queries, and health determination logic, see xref:quay_jtbd-integrate.adoc#mirroring-metrics-health[Monitoring repository mirroring].
+For metric names, example Prometheus queries, and health determination logic, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#mirroring-metrics-health[Monitoring repository mirroring].

--- a/modules/arch-intro-recent-features.adoc
+++ b/modules/arch-intro-recent-features.adoc
@@ -8,4 +8,4 @@
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-whats_new.adoc[{productname} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/release_notes/index[{productname} Release Notes]

--- a/modules/builds-automation-configuration-overview.adoc
+++ b/modules/builds-automation-configuration-overview.adoc
@@ -16,4 +16,4 @@ These options help you streamline your CI/CD pipeline, enforce build policies, a
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-develop.adoc[Builders and automation]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/builders_and_image_automation/index[Builders and automation]

--- a/modules/clair-troubleshooting-issues.adoc
+++ b/modules/clair-troubleshooting-issues.adoc
@@ -28,6 +28,6 @@ In some cases, you might receive an *Unsupported* message. This might indicate t
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#clair-updaters[Clair vulnerability databases]
-* xref:quay_jtbd-configure.adoc#clair-updater-urls[Clair updater URLs]
-* xref:quay_jtbd-configure.adoc#config-fields-overview[Clair configuration overview]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#clair-updaters[Clair vulnerability databases]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#clair-updater-urls[Clair updater URLs]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#config-fields-overview[Clair configuration overview]

--- a/modules/clair-vulnerability-scanner-overview.adoc
+++ b/modules/clair-vulnerability-scanner-overview.adoc
@@ -31,12 +31,12 @@ ifeval::["{context}" == "quay-security"]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc[Vulnerability reporting with Clair on {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index[Vulnerability reporting with Clair on {productname}]
 endif::[]
 
 ifeval::["{context}" == "quay-configuration"]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#config-fields-overview[Clair configuration overview]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#config-fields-overview[Clair configuration overview]
 endif::[]

--- a/modules/con_quay_ha_prereq.adoc
+++ b/modules/con_quay_ha_prereq.adoc
@@ -78,7 +78,7 @@ Production quality deployments of {productname} generally use Podman. Docker has
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc[Configure {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index[Configure {productname}]
 * link:https://access.crunchydata.com/documentation/postgres-operator/latest/[Postgres Operator]
 * link:https://www.crunchydata.com/[Crunchy Data]
 * link:https://access.redhat.com/support/policy/updates/rhquay/policies[{productname} Support Policy]

--- a/modules/con_quay_intro.adoc
+++ b/modules/con_quay_intro.adoc
@@ -46,4 +46,4 @@ Do not use "Locally mounted directory" Storage Engine for any production configu
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-discover.adoc[{productname} architecture guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index[{productname} architecture guide]

--- a/modules/con_schema.adoc
+++ b/modules/con_schema.adoc
@@ -8,4 +8,4 @@ Most {productname} configuration options are stored in the `config.yaml` file an
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc[{productname} Configuration Guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index[{productname} Configuration Guide]

--- a/modules/config-debug-variables.adoc
+++ b/modules/config-debug-variables.adoc
@@ -39,4 +39,4 @@ FEATURE_AGGREGATED_LOG_COUNT_RETRIEVAL: true
 ----
 
 .Additional resources
-* xref:quay_jtbd-troubleshoot.adoc[Troubleshooting {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/troubleshooting_red_hat_quay/index[Troubleshooting {productname}]

--- a/modules/config-fields-actionlog.adoc
+++ b/modules/config-fields-actionlog.adoc
@@ -123,4 +123,4 @@ ACTION_LOG_AUDIT_DELETE_FAILURES: false
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#proc_manage-log-storage[Configuring action log storage for Elasticsearch and Splunk]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#proc_manage-log-storage[Configuring action log storage for Elasticsearch and Splunk]

--- a/modules/config-fields-ipv6.adoc
+++ b/modules/config-fields-ipv6.adoc
@@ -26,5 +26,5 @@ FEATURE_LISTEN_IP_VERSION: dual-stack
 
 [role="_additional-resources"]
 .Additional resources
-* xref:quay_jtbd-configure.adoc#proc_manage-ipv6-dual-stack[Deploying IPv6 on {productname-ocp}]
-* xref:quay_jtbd-configure.adoc#proc_manage-ipv6-dual-stack[IPv6 and dual-stack deployments]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#proc_manage-ipv6-dual-stack[Deploying IPv6 on {productname-ocp}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#proc_manage-ipv6-dual-stack[IPv6 and dual-stack deployments]

--- a/modules/config-fields-ldap.adoc
+++ b/modules/config-fields-ldap.adoc
@@ -13,7 +13,7 @@ This section provides YAML examples for the following LDAP scenarios:
 
 .Additional resources
 
-* xref:quay_jtbd-secure.adoc#ldap-authentication-setup-for-quay-enterprise[LDAP Authentication setup for {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#ldap-authentication-setup-for-quay-enterprise[LDAP Authentication setup for {productname}]
 
 .LDAP configuration
 [cols="2a,1a,2a",options="header"]

--- a/modules/config-fields-mirroring-repository.adoc
+++ b/modules/config-fields-mirroring-repository.adoc
@@ -8,7 +8,7 @@ Mirroring in {productname} enables automatic synchronization of repositories wit
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-integrate.adoc#arch-mirroring-intro[Repository mirroring]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index#arch-mirroring-intro[Repository mirroring]
 
 .Mirroring configuration
 [cols="3a,1a,2a",options="header"]

--- a/modules/config-fields-modelcard-rendering.adoc
+++ b/modules/config-fields-modelcard-rendering.adoc
@@ -40,5 +40,5 @@ where:
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-administer.adoc#viewing-model-card-information[Viewing model card information by using the UI]
-* xref:quay_jtbd-administer.adoc#creating-an-image-repository-via-skopeo-copy[Creating a repository by using Skopeo]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#viewing-model-card-information[Viewing model card information by using the UI]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#creating-an-image-repository-via-skopeo-copy[Creating a repository by using Skopeo]

--- a/modules/config-fields-oauth.adoc
+++ b/modules/config-fields-oauth.adoc
@@ -99,4 +99,4 @@ GOOGLE_LOGIN_CONFIG:
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-develop.adoc#reassigning-oauth-access-token[Reassigning an OAuth access token]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#reassigning-oauth-access-token[Reassigning an OAuth access token]

--- a/modules/config-fields-referrers-api.adoc
+++ b/modules/config-fields-referrers-api.adoc
@@ -12,7 +12,7 @@ The following configuration field enables the OCI referrers API to retrieve and 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-develop.adoc#oci-intro[Attaching referrers to an image]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#oci-intro[Attaching referrers to an image]
 
 .Referrers API configuration field
 [cols="3a,1a,2a",options="header"]

--- a/modules/config-fields-registry-state.adoc
+++ b/modules/config-fields-registry-state.adoc
@@ -31,4 +31,4 @@ WEBHOOK_HOSTNAME_BLACKLIST:
 
 [role="_additional-resources"]
 .Additional resources
-* xref:quay_jtbd-administer.adoc#optional-enabling-read-only-mode-backup-restore-standalone[Enabling read-only mode for {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#optional-enabling-read-only-mode-backup-restore-standalone[Enabling read-only mode for {productname}]

--- a/modules/config-fields-robot-account.adoc
+++ b/modules/config-fields-robot-account.adoc
@@ -25,4 +25,4 @@ ROBOTS_DISALLOW: true
 
 [role="_additional-resources"]
 .Additional resources
-* xref:quay_jtbd-administer.adoc#disabling-robot-account[Disabling robot accounts]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#disabling-robot-account[Disabling robot accounts]

--- a/modules/config-fields-ssl.adoc
+++ b/modules/config-fields-ssl.adoc
@@ -36,4 +36,4 @@ EXTERNAL_TLS_TERMINATION: true
 [id="additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[SSL and TLS for {productname}]

--- a/modules/config-fields-storage-local.adoc
+++ b/modules/config-fields-storage-local.adoc
@@ -25,4 +25,4 @@ DISTRIBUTED_STORAGE_PREFERENCE:
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-install.adoc[Proof of Concept - Deploying {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[Proof of Concept - Deploying {productname}]

--- a/modules/config-preconfigure-automation-intro.adoc
+++ b/modules/config-preconfigure-automation-intro.adoc
@@ -18,5 +18,5 @@ Automation options are ideal for environments that require declarative {productn
 .Additional resources
 
 * xref:quay_jtbd-configure.adoc#modifying-quayregistry-cr-after-deployment[Modifying the QuayRegistry CR after deployment]
-* xref:quay_jtbd-develop.adoc[{productname} API guide]
-* xref:quay_jtbd-reference.adoc[{productname} API reference]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index[{productname} API guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index[{productname} API reference]

--- a/modules/config-preconfigure-automation.adoc
+++ b/modules/config-preconfigure-automation.adoc
@@ -39,5 +39,5 @@ FEATURE_USER_CREATION: false
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-develop.adoc#token-overview[OAuth 2 access token overview]
-* xref:quay_jtbd-develop.adoc[{productname} API guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#token-overview[OAuth 2 access token overview]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index[{productname} API guide]

--- a/modules/configuring-cert-based-auth-quay-cloudsql.adoc
+++ b/modules/configuring-cert-based-auth-quay-cloudsql.adoc
@@ -11,7 +11,7 @@ This procedure uses CloudSQL as an example and also applies to PostgreSQL and ot
 
 * You have generated custom Certificate Authorities (CAs) and your SSL/TLS certificates and keys are available in `PEM` format that will be used to generate an SSL connection with your CloudSQL database. For more information, see xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[SSL and TLS for {productname}].
 * You have `base64 decoded` the original config bundle into a `config.yaml` file. For more information, see xref:quay_jtbd-configure.adoc#operator-config-cli-download[Downloading the existing configuration].
-* You are using an externally managed PostgreSQL or CloudSQL database. For more information, see xref:quay_jtbd-configure.adoc#operator-unmanaged-postgres[Using and existing PostgreSQL database] with the `DB_URI` variable set.
+* You are using an externally managed PostgreSQL or CloudSQL database. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#operator-unmanaged-postgres[Using and existing PostgreSQL database] with the `DB_URI` variable set.
 * Your externally managed PostgreSQL or CloudSQL database is configured for SSL/TLS.
 * The `postgres` component of your `QuayRegistry` CRD is set to `managed: false`, and your CloudSQL database is set with the `DB_URI` configuration variable. The following procedure uses `postgresql://<cloudsql_username>:<dbpassword>@<database_host>:<port>/<database_name>`.
 
@@ -73,7 +73,7 @@ DB_URI: postgresql://<dbusername>:<dbpassword>@<database_host>:<port>/<database_
 +
 where:
 
-`DB_CONNECTION_ARGS.sslmode`:: Specifies `verify-ca`, which ensures that the database connection uses SSL/TLS and verifies the server certificate against a trusted CA. This can work with both trusted CA and self-signed CA certificates. However, this mode does not verify the hostname of the server. For full hostname and certificate verification, use `verify-full`. For more information about the configuration options available, see xref:quay_jtbd-configure.adoc#config-fields-postgres[PostgreSQL SSL/TLS connection arguments].
+`DB_CONNECTION_ARGS.sslmode`:: Specifies `verify-ca`, which ensures that the database connection uses SSL/TLS and verifies the server certificate against a trusted CA. This can work with both trusted CA and self-signed CA certificates. However, this mode does not verify the hostname of the server. For full hostname and certificate verification, use `verify-full`. For more information about the configuration options available, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-postgres[PostgreSQL SSL/TLS connection arguments].
 `DB_CONNECTION_ARGS.sslrootcert`:: Specifies the `root.crt` file that contains the root certificate used to verify the SSL/TLS connection with your CloudSQL database. This file is mounted in the `Quay` pod from the Kubernetes secret.
 `DB_CONNECTION_ARGS.sslcert`:: Specifies the `postgresql.crt` file that contains the client certificate used to authenticate the connection to your CloudSQL database. This file is mounted in the `Quay` pod from the Kubernetes secret.
 `DB_CONNECTION_ARGS.sslkey`:: Specifies the `postgresql.key` file that contains the private key associated with the client certificate. This file is mounted in the `Quay` pod from the Kubernetes secret.

--- a/modules/configuring-geo-repl.adoc
+++ b/modules/configuring-geo-repl.adoc
@@ -108,7 +108,7 @@ spec:
 +
 [NOTE]
 ====
-Because SSL/TLS is unmanaged, and the route is managed, you must supply the certificates directly in the config bundle. For more information, see xref:quay_jtbd-configure.adoc#configuring-ssl-tls-routes[Configuring SSL/TLS and Routes]. 
+Because SSL/TLS is unmanaged, and the route is managed, you must supply the certificates directly in the config bundle. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#configuring-ssl-tls-routes[Configuring SSL/TLS and Routes]. 
 ====
 +
 [source,yaml]
@@ -150,5 +150,5 @@ spec:
 +
 [NOTE]
 ====
-Because SSL/TLS is unmanaged, and the route is managed, you must supply the certificates directly in the config bundle. For more information, see xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[Configuring SSL and TLS for {productname}.] 
+Because SSL/TLS is unmanaged, and the route is managed, you must supply the certificates directly in the config bundle. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[Configuring SSL and TLS for {productname}.] 
 ====

--- a/modules/configuring-programmatic-bootstrap-ocp.adoc
+++ b/modules/configuring-programmatic-bootstrap-ocp.adoc
@@ -13,7 +13,7 @@ Programmatic bootstrap token provisioning is a Tech Preview feature in {productn
 .Prerequisites
 
 * You have deployed a {productname} registry on {ocp} by using the {productname} Operator.
-* You have created at least one superuser account. For more information, see xref:quay_jtbd-install.adoc#creating-first-user[Creating the first user].
+* You have created at least one superuser account. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#creating-first-user[Creating the first user].
 * You can edit the `configBundleSecret` resource that is referenced by your `QuayRegistry` custom resource (CR).
 
 .Procedure

--- a/modules/configuring-red-hat-sso.adoc
+++ b/modules/configuring-red-hat-sso.adoc
@@ -14,4 +14,4 @@ By configuring Red Hat Single Sign-On on {productname}, you can create a seamles
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.0[Red Hat Single Sign-On]
 * link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.6/html-single/server_installation_and_configuration_guide/index#operator[Red Hat Single Sign-On Operator]
-* xref:quay_jtbd-secure.adoc#operator-custom-ssl-certs-config-bundle[SSL/TLS for your {productname-ocp} deployment]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-custom-ssl-certs-config-bundle[SSL/TLS for your {productname-ocp} deployment]

--- a/modules/core-prereqs-storage.adoc
+++ b/modules/core-prereqs-storage.adoc
@@ -31,5 +31,5 @@ Geo-replication:: Local storage cannot be used for geo-replication. Geo-replicat
 .Additional resources
 
 * link:https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation[{odf}]
-* xref:quay_jtbd-plan.adoc#set-up-ceph[Quay High Availability Guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploy_red_hat_quay_-_high_availability/index#set-up-ceph[Quay High Availability Guide]
 * link:https://docs.redhat.com/en/documentation/red_hat_ceph_storage/5/html-single/architecture_guide/index[Red Hat Ceph Storage Architecture Guide]

--- a/modules/creating-a-team-api.adoc
+++ b/modules/creating-a-team-api.adoc
@@ -12,11 +12,11 @@ To create a team for an organization in {productname}, you can use the API. You 
 .Prerequisites 
 
 * You have created an organization. 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following xref:quay_jtbd-reference.adoc#updateorganizationteam[`PUT /api/v1/organization/{orgname}/team/{teamname}`] command to create a team for your organization:
+. Enter the following link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#updateorganizationteam[`PUT /api/v1/organization/{orgname}/team/{teamname}`] command to create a team for your organization:
 +
 [source,terminal]
 ----

--- a/modules/creating-an-image-repository-via-the-api.adoc
+++ b/modules/creating-an-image-repository-via-the-api.adoc
@@ -16,11 +16,11 @@ endif::[]
 
 .Prerequisites 
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following command to create a repository using the xref:quay_jtbd-reference.adoc#createrepo[`POST /api/v1/repository`] endpoint:
+. Enter the following command to create a repository using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#createrepo[`POST /api/v1/repository`] endpoint:
 +
 [source,terminal]
 ----

--- a/modules/default-permissions-api.adoc
+++ b/modules/default-permissions-api.adoc
@@ -12,11 +12,11 @@ To create, update, or delete default permissions for an {productname} organizati
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following command to create a default permission with the xref:quay_jtbd-reference.adoc#createorganizationprototypepermission[`POST /api/v1/organization/{orgname}/prototypes`] endpoint:
+. Enter the following command to create a default permission with the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#createorganizationprototypepermission[`POST /api/v1/organization/{orgname}/prototypes`] endpoint:
 +
 [source,terminal]
 ----
@@ -38,7 +38,7 @@ $ curl -X POST   -H "Authorization: Bearer <bearer_token>"   -H "Content-Type: a
 {"activating_user": {"name": "test-org+test", "is_robot": true, "kind": "user", "is_org_member": true, "avatar": {"name": "test-org+test", "hash": "aa85264436fe9839e7160bf349100a9b71403a5e9ec684d5b5e9571f6c821370", "color": "#8c564b", "kind": "robot"}}, "delegate": {"name": "testuser", "is_robot": false, "kind": "user", "is_org_member": false, "avatar": {"name": "testuser", "hash": "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a", "color": "#6b6ecf", "kind": "user"}}, "role": "admin", "id": "977dc2bc-bc75-411d-82b3-604e5b79a493"}
 ----
 
-. Enter the following command to update a default permission using the xref:quay_jtbd-reference.adoc#updateorganizationprototypepermission[`PUT /api/v1/organization/{orgname}/prototypes/{prototypeid}`] endpoint, for example, if you want to change the permission type. You must include the ID that was returned when you created the policy.
+. Enter the following command to update a default permission using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#updateorganizationprototypepermission[`PUT /api/v1/organization/{orgname}/prototypes/{prototypeid}`] endpoint, for example, if you want to change the permission type. You must include the ID that was returned when you created the policy.
 +
 [source,terminal]
 ----
@@ -57,7 +57,7 @@ $ curl -X PUT \
 {"activating_user": {"name": "test-org+test", "is_robot": true, "kind": "user", "is_org_member": true, "avatar": {"name": "test-org+test", "hash": "aa85264436fe9839e7160bf349100a9b71403a5e9ec684d5b5e9571f6c821370", "color": "#8c564b", "kind": "robot"}}, "delegate": {"name": "testuser", "is_robot": false, "kind": "user", "is_org_member": false, "avatar": {"name": "testuser", "hash": "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a", "color": "#6b6ecf", "kind": "user"}}, "role": "write", "id": "977dc2bc-bc75-411d-82b3-604e5b79a493"}
 ----
 
-. You can delete the permission by entering the xref:quay_jtbd-reference.adoc#deleteorganizationprototypepermission[`DELETE /api/v1/organization/{orgname}/prototypes/{prototypeid}`] command:
+. You can delete the permission by entering the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#deleteorganizationprototypepermission[`DELETE /api/v1/organization/{orgname}/prototypes/{prototypeid}`] command:
 +
 [source,terminal]
 ----
@@ -67,7 +67,7 @@ curl -X DELETE \
   https://<quay-server.example.com>/api/v1/organization/<organization_name>/prototypes/<prototype_id>
 ----
 +
-This command does not return an output. Instead, you can obtain a list of all permissions by entering the xref:quay_jtbd-reference.adoc#getorganizationprototypepermissions[`GET /api/v1/organization/{orgname}/prototypes`] command:
+This command does not return an output. Instead, you can obtain a list of all permissions by entering the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getorganizationprototypepermissions[`GET /api/v1/organization/{orgname}/prototypes`] command:
 +
 [source,terminal]
 ----

--- a/modules/deleting-a-tag-api.adoc
+++ b/modules/deleting-a-tag-api.adoc
@@ -7,11 +7,11 @@ To remove an image tag from a {productname} repository, you can use the API.
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. You can delete an image tag by using the xref:quay_jtbd-reference.adoc#deletefulltag[`DELETE /api/v1/repository/{repository}/tag/{tag}`] command:
+. You can delete an image tag by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#deletefulltag[`DELETE /api/v1/repository/{repository}/tag/{tag}`] command:
 +
 [source,terminal]
 ----
@@ -22,7 +22,7 @@ $ curl -X DELETE \
 +
 This command does not return output in the CLI. Continue on to the next step to return a list of tags.
 
-. To see a list of tags after deleting a tag, you can use the xref:quay_jtbd-reference.adoc#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
+. To see a list of tags after deleting a tag, you can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
 +
 [source,terminal]
 ----

--- a/modules/deleting-an-image-repository-via-the-api.adoc
+++ b/modules/deleting-an-image-repository-via-the-api.adoc
@@ -12,18 +12,18 @@ To delete a repository from {productname}, you can use the API.
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following command to delete a repository using the xref:quay_jtbd-reference.adoc#deleterepository[`DELETE /api/v1/repository/{repository}`] endpoint:
+. Enter the following command to delete a repository using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#deleterepository[`DELETE /api/v1/repository/{repository}`] endpoint:
 +
 [source,terminal]
 ----
 $ curl -X DELETE   -H "Authorization: Bearer <bearer_token>" "<quay-server.example.com>/api/v1/repository/<namespace>/<repository_name>"
 ----
 
-. The CLI does not return information when deleting a repository from the CLI. To confirm deletion, you can check the {productname} UI, or you can enter the following xref:quay_jtbd-reference.adoc#getrepo[`GET /api/v1/repository/{repository}`] command to see if details are returned for the deleted repository:
+. The CLI does not return information when deleting a repository from the CLI. To confirm deletion, you can check the {productname} UI, or you can enter the following link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getrepo[`GET /api/v1/repository/{repository}`] command to see if details are returned for the deleted repository:
 +
 [source,terminal]
 ----

--- a/modules/enabling-using-the-api.adoc
+++ b/modules/enabling-using-the-api.adoc
@@ -16,5 +16,5 @@ Detailed instructions for how to use the {productname} API are available in the 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-reference.adoc[{productname} API guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index[{productname} API guide]
 endif::[]

--- a/modules/integrating-external-postgresql-db.adoc
+++ b/modules/integrating-external-postgresql-db.adoc
@@ -45,6 +45,6 @@ This procedure can also be done by using the `oc` CLI and following the instruct
 DB_URI: postgresql://test-quay-database:postgres@test-quay-database:5432/test-quay-database
 ----
 
-. Optional: Add additional database configuration fields, such as `DB_CONNECTION_ARGS` or SSL/TLS connection arguments. For more information, see xref:quay_jtbd-configure.adoc#config-fields-db[Database connection arguments].
+. Optional: Add additional database configuration fields, such as `DB_CONNECTION_ARGS` or SSL/TLS connection arguments. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-db[Database connection arguments].
 
 . Click *Save*.

--- a/modules/ldap-configuration-fields-link.adoc
+++ b/modules/ldap-configuration-fields-link.adoc
@@ -8,4 +8,4 @@ You can find the full list of LDAP configuration fields for {productname} in the
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#config-fields-ldap[LDAP configuration fields]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-ldap[LDAP configuration fields]

--- a/modules/minimal-configuration-local-storage.adoc
+++ b/modules/minimal-configuration-local-storage.adoc
@@ -11,7 +11,7 @@ A minimal `config.yaml` for on-premises {productname} uses local storage for ima
 
 [IMPORTANT]
 ====
-Only use local storage when deploying a registry for proof of concept purposes. Local storage is not intended for production purposes. When using local storage, you must map the registry to a local directory to the `datastorage` path in the container when starting the registry. For more information, see xref:quay_jtbd-install.adoc[Proof of Concept - Deploying {productname}]
+Only use local storage when deploying a registry for proof of concept purposes. Local storage is not intended for production purposes. When using local storage, you must map the registry to a local directory to the `datastorage` path in the container when starting the registry. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[Proof of Concept - Deploying {productname}]
 ====
 
 .Local storage minimal configuration

--- a/modules/mirroring-api-intro.adoc
+++ b/modules/mirroring-api-intro.adoc
@@ -10,4 +10,4 @@ image:swagger-mirroring.png[Mirroring API]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-reference.adoc[{productname} API Guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index[{productname} API Guide]

--- a/modules/mirroring-events.adoc
+++ b/modules/mirroring-events.adoc
@@ -10,4 +10,4 @@ The events can be configured inside of the *Settings* tab for each repository, a
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-integrate.adoc#mirroring-metrics-health[Monitoring repository mirroring]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#mirroring-metrics-health[Monitoring repository mirroring]

--- a/modules/mirroring-metrics-health.adoc
+++ b/modules/mirroring-metrics-health.adoc
@@ -105,10 +105,10 @@ $ curl -X GET "https://<quay-server.example.com>/api/v1/superuser/mirror/health"
      -H "Authorization: Bearer <access_token>"
 ----
 
-For endpoint parameters, response schema, and authorization requirements, see xref:quay_jtbd-reference.adoc#getrepositorymirrorhealth[getRepositoryMirrorHealth] and xref:quay_jtbd-reference.adoc#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth].
+For endpoint parameters, response schema, and authorization requirements, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getrepositorymirrorhealth[getRepositoryMirrorHealth] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth].
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#operator-unmanaged-monitoring[Enabling monitoring when the {productname} Operator is installed in a single namespace]
-* xref:quay_jtbd-whats_new.adoc#repository-mirror-metrics-health[Repository mirror metrics and health monitoring]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#operator-unmanaged-monitoring[Enabling monitoring when the {productname} Operator is installed in a single namespace]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/release_notes/index#repository-mirror-metrics-health[Repository mirror metrics and health monitoring]

--- a/modules/modifying-quayregistry-cr-cli.adoc
+++ b/modules/modifying-quayregistry-cr-cli.adoc
@@ -22,7 +22,7 @@ $ oc edit quayregistry <registry_name> -n <namespace>
 +
 [NOTE]
 ====
-Setting a component to unmanaged (`managed: false`) might require additional configuration. For more information about setting unmanaged components in the `QuayRegistry` CR, see xref:quay_jtbd-configure.adoc#operator-components-unmanaged[Using unmanaged components for dependencies].
+Setting a component to unmanaged (`managed: false`) might require additional configuration. For more information about setting unmanaged components in the `QuayRegistry` CR, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#operator-components-unmanaged[Using unmanaged components for dependencies].
 ====
 
 . Save the changes.

--- a/modules/modifying-quayregistry-cr-ui.adoc
+++ b/modules/modifying-quayregistry-cr-ui.adoc
@@ -28,5 +28,5 @@ To modify the `QuayRegistry` custom resource in {productname}, you can use the {
 +
 [NOTE]
 ====
-Setting a component to unmanaged (`managed: false`) might require additional configuration. For more information about setting unmanaged components in the `QuayRegistry` CR, see xref:quay_jtbd-configure.adoc#operator-components-unmanaged[Using unmanaged components for dependencies].
+Setting a component to unmanaged (`managed: false`) might require additional configuration. For more information about setting unmanaged components in the `QuayRegistry` CR, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#operator-components-unmanaged[Using unmanaged components for dependencies].
 ====

--- a/modules/new-api-endpoints-318.adoc
+++ b/modules/new-api-endpoints-318.adoc
@@ -12,7 +12,7 @@ Robot federation configuration entries now support an optional `audiences` array
 
 A future release requires the `audiences` field for federated robot authentication.
 
-Configure federation entries by using the UI or `POST /api/v1/organization/{orgname}/robots/{robot_shortname}/federation`. In {productname} 3.18, create and update requests persist `issuer` and `subject` only; audience validation applies when `audiences` is present in the stored federation configuration. For field descriptions, examples, and current API limitations, see xref:quay_jtbd-reference.adoc#createorgrobotfederation[createOrgRobotFederation] and xref:quay_jtbd-secure.adoc#configuring-federation-audiences[Configuring federation audiences].
+Configure federation entries by using the UI or `POST /api/v1/organization/{orgname}/robots/{robot_shortname}/federation`. In {productname} 3.18, create and update requests persist `issuer` and `subject` only; audience validation applies when `audiences` is present in the stored federation configuration. For field descriptions, examples, and current API limitations, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#createorgrobotfederation[createOrgRobotFederation] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#configuring-federation-audiences[Configuring federation audiences].
 
 [id="organization-application-token-api-318"]
 == Organization application OAuth token life cycle
@@ -29,14 +29,14 @@ Configure federation entries by using the UI or `POST /api/v1/organization/{orgn
 
 Create requests accept `name`, `scope`, and optional `expiration` (seconds). The bearer token secret is returned only in the create response.
 
-For API schemas and examples, see xref:quay_jtbd-reference.adoc#createorganizationapplicationtoken[createOrganizationApplicationToken], xref:quay_jtbd-reference.adoc#listorganizationapplicationtokens[listOrganizationApplicationTokens], and xref:quay_jtbd-reference.adoc#deleteorganizationapplicationtoken[deleteOrganizationApplicationToken].
+For API schemas and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#createorganizationapplicationtoken[createOrganizationApplicationToken], link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listorganizationapplicationtokens[listOrganizationApplicationTokens], and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#deleteorganizationapplicationtoken[deleteOrganizationApplicationToken].
 
 [id="bootstrap-token-renewal-api-318"]
 == Bootstrap token renewal
 
 When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, `POST /api/v1/bootstrap/renew` rotates the bootstrap OAuth token. The new token is written to the configured filesystem path or Kubernetes Secret, and the previous token is invalidated immediately. The response is `{"status": "rotated"}`.
 
-For more information, see xref:quay_jtbd-reference.adoc#renewbootstraptoken[renewBootstrapToken] and xref:quay_jtbd-administer.adoc#renewing-bootstrap-token[Renewing the bootstrap token].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#renewbootstraptoken[renewBootstrapToken] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#renewing-bootstrap-token[Renewing the bootstrap token].
 The following API endpoints were added in {productname} 3.18.
 
 [id="repository-mirror-health-api"]
@@ -51,4 +51,4 @@ New health endpoints report the status of repository mirroring operations, inclu
 | *getSuperUserRepositoryMirrorHealth* | Return a global mirror health summary for superusers without repository-identifying samples. Returns HTTP `200` when healthy and HTTP `503` when unhealthy. | object
 |===
 
-See xref:quay_jtbd-reference.adoc#getrepositorymirrorhealth[getRepositoryMirrorHealth] and xref:quay_jtbd-reference.adoc#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth] for more information, including example commands.
+See link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getrepositorymirrorhealth[getRepositoryMirrorHealth] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth] for more information, including example commands.

--- a/modules/new-features-and-enhancements-318.adoc
+++ b/modules/new-features-and-enhancements-318.adoc
@@ -16,7 +16,7 @@ This enhancement enables integrations with Red Hat Developer Hub (RHDH), Red Hat
 
 Federated robot authentication also supports an optional `audiences` array on each federation configuration entry. When configured, {productname} validates the external OIDC token audience during robot token exchange. When absent, audience validation is skipped and a deprecation warning is logged. For more information, see xref:quay_jtbd-whats_new.adoc#robot-federation-audiences-318[Robot federation `audiences` field].
 
-For configuration field descriptions, see xref:quay_jtbd-whats_new.adoc#oidc-multi-issuer-config-fields-318[OIDC multi-issuer configuration fields]. For setup and migration procedures, see xref:quay_jtbd-secure.adoc#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC].
+For configuration field descriptions, see xref:quay_jtbd-whats_new.adoc#oidc-multi-issuer-config-fields-318[OIDC multi-issuer configuration fields]. For setup and migration procedures, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC].
 
 [id="programmatic-oauth-token-provisioning-318"]
 == Programmatic OAuth token provisioning (Tech Preview)
@@ -27,7 +27,7 @@ When `FEATURE_PROGRAMMATIC_BOOTSTRAP` is enabled, {productname} can also auto-ge
 
 This feature is available as Tech Preview in {productname} 3.18.
 
-For configuration fields, see xref:quay_jtbd-whats_new.adoc#programmatic-bootstrap-config-fields-318[Programmatic bootstrap configuration fields]. For setup and examples, see xref:quay_jtbd-administer.adoc#programmatic-oauth-token-provisioning[Programmatic OAuth token provisioning].
+For configuration fields, see xref:quay_jtbd-whats_new.adoc#programmatic-bootstrap-config-fields-318[Programmatic bootstrap configuration fields]. For setup and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#programmatic-oauth-token-provisioning[Programmatic OAuth token provisioning].
 
 [id="oauth-api-access-tokens-ui-318"]
 == OAuth API Access Tokens management UI
@@ -36,7 +36,7 @@ With this release, organization OAuth applications include an *API Access Tokens
 
 Existing tokens continue to work for up to 10 years until you revoke them.
 
-For more information, see xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Creating an OAuth 2 access token] and xref:quay_jtbd-develop.adoc#rotating-legacy-oauth-access-token[Rotating a legacy OAuth 2 access token].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Creating an OAuth 2 access token] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#rotating-legacy-oauth-access-token[Rotating a legacy OAuth 2 access token].
 
 [id="repository-mirror-metrics-health"]
 == Repository mirror metrics and health monitoring
@@ -50,4 +50,4 @@ Four new per-repository metrics are available from the mirror worker metrics end
 * `quay_repository_mirror_sync_complete` — whether all tags synchronized in the last run
 * `quay_repository_mirror_sync_failures_total` — cumulative failure count by namespace and reason
 
-For more information, see xref:quay_jtbd-integrate.adoc#mirroring-metrics-health[Monitoring repository mirroring], xref:quay_jtbd-reference.adoc#getrepositorymirrorhealth[getRepositoryMirrorHealth], and xref:quay_jtbd-reference.adoc#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#mirroring-metrics-health[Monitoring repository mirroring], link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getrepositorymirrorhealth[getRepositoryMirrorHealth], and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getsuperuserrepositorymirrorhealth[getSuperUserRepositoryMirrorHealth].

--- a/modules/new-features-and-enhancements-quay-ocp-318.adoc
+++ b/modules/new-features-and-enhancements-quay-ocp-318.adoc
@@ -28,14 +28,14 @@ To fully override or preserve TLS behavior, set both `SSL_PROTOCOLS` and `SSL_CI
 
 [IMPORTANT]
 ====
-If you use unmanaged TLS and require specific TLS settings that differ from the cluster default, set both `SSL_PROTOCOLS` and `SSL_CIPHERS` in your `configBundleSecret` resource before upgrading. Setting only one field disables cluster-profile inheritance for both fields. For more information, see xref:quay_jtbd-upgrade.adoc#preserving-tls-settings-operator-upgrade_upgrade_red_hat_quay_on_openshift_container_platform[Preserving TLS settings before upgrading {productname-ocp}].
+If you use unmanaged TLS and require specific TLS settings that differ from the cluster default, set both `SSL_PROTOCOLS` and `SSL_CIPHERS` in your `configBundleSecret` resource before upgrading. Setting only one field disables cluster-profile inheritance for both fields. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/upgrade_red_hat_quay/index#preserving-tls-settings-operator-upgrade_upgrade_red_hat_quay_on_openshift_container_platform[Preserving TLS settings before upgrading {productname-ocp}].
 ====
 
 On Kubernetes clusters without the `config.openshift.io` API, the Operator does not inject TLS settings and {productname} uses its built-in defaults.
 
-For more information about SSL/TLS configuration fields, see xref:quay_jtbd-configure.adoc#config-fields-ssl[SSL/TLS configuration fields].
+For more information about SSL/TLS configuration fields, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-ssl[SSL/TLS configuration fields].
 
-For information about custom certificates and the config bundle, see xref:quay_jtbd-secure.adoc#operator-custom-ssl-certs-config-bundle[Configuring custom SSL/TLS certificates for {productname-ocp}]. For information about TLS protocol and cipher inheritance, see xref:quay_jtbd-secure.adoc#operator-ocp-tls-security-profile[{ocp} cluster TLS security profile inheritance].
+For information about custom certificates and the config bundle, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-custom-ssl-certs-config-bundle[Configuring custom SSL/TLS certificates for {productname-ocp}]. For information about TLS protocol and cipher inheritance, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-ocp-tls-security-profile[{ocp} cluster TLS security profile inheritance].
 
 For more information about NIST post-quantum cryptography standards, see link:https://csrc.nist.gov/projects/post-quantum-cryptography[Post-Quantum Cryptography]. 
 
@@ -67,7 +67,7 @@ For example, to tune Redis resources for a smaller cluster, add an entry like th
             memory: 400Mi
 ----
 
-For more information about configuring resource requests and limits, see xref:quay_jtbd-optimize.adoc#configuring-resources-managed-components[Configuring QuayRegistry CR resources].
+For more information about configuring resource requests and limits, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#configuring-resources-managed-components[Configuring QuayRegistry CR resources].
 
 [id="clair-ephemeral-storage-overrides-rn"]
 == Clair ephemeral storage overrides
@@ -89,7 +89,7 @@ For example:
 
 These overrides apply to Clair scratch storage only. They do not resize the managed Clair PostgreSQL database.
 
-For more information, see xref:quay_jtbd-install.adoc#clair-ephemeral-storage-overrides[Configuring ephemeral storage for managed Clair].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/vulnerability_reporting_with_clair_on_red_hat_quay/index#clair-ephemeral-storage-overrides[Configuring ephemeral storage for managed Clair].
 
 [id="external-tls-secret-reference"]
 == External TLS Secret reference for the QuayRegistry CR
@@ -98,7 +98,7 @@ The {productname} Operator supports referencing an external `kubernetes.io/tls` 
 
 The `QuayRegistry` status includes a `ComponentTLSReady` condition that reports whether TLS from the external Secret is valid and applied.
 
-For configuration steps, see xref:quay_jtbd-secure.adoc#operator-external-tls-secret-reference[Referencing an external TLS Secret for {productname-ocp}]. For a cert-manager example, see xref:quay_jtbd-secure.adoc#example-certificate-manager[Example: Using cert-manager with an external TLS Secret].
+For configuration steps, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-external-tls-secret-reference[Referencing an external TLS Secret for {productname-ocp}]. For a cert-manager example, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#example-certificate-manager[Example: Using cert-manager with an external TLS Secret].
 [id="operator-managed-postgres-tls-rn"]
 == TLS encryption for Operator-managed PostgreSQL
 
@@ -119,4 +119,4 @@ You can enable TLS independently for the `postgres` and `clairpostgres` componen
 This feature configures transport encryption for Operator-managed PostgreSQL. Transport encryption is distinct from the managed `tls` component, which handles {productname}'s external HTTPS endpoint.
 ====
 
-For configuration examples, certificate options, and verification steps, see xref:quay_jtbd-secure.adoc#operator-managed-postgres-tls[TLS encryption for Operator-managed PostgreSQL].
+For configuration examples, certificate options, and verification steps, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-managed-postgres-tls[TLS encryption for Operator-managed PostgreSQL].

--- a/modules/new-quay-config-fields-318.adoc
+++ b/modules/new-quay-config-fields-318.adoc
@@ -10,7 +10,7 @@ You can review configuration fields that are new or changed in {productname} 3.1
 
 When you deploy {productname-ocp}, the Operator can populate the existing `SSL_PROTOCOLS` and `SSL_CIPHERS` fields from the cluster-wide {ocp} `tlsSecurityProfile` when neither field is set in the `configBundleSecret` resource. To fully override or preserve TLS behavior, set both fields. Setting either field disables cluster-profile inheritance for both fields.
 
-For more information, see xref:quay_jtbd-secure.adoc#operator-ocp-tls-security-profile[{ocp} cluster TLS security profile inheritance] and xref:quay_jtbd-upgrade.adoc#preserving-tls-settings-operator-upgrade_upgrade_red_hat_quay_on_openshift_container_platform[Preserving TLS settings before upgrading {productname-ocp}].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-ocp-tls-security-profile[{ocp} cluster TLS security profile inheritance] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/upgrade_red_hat_quay/index#preserving-tls-settings-operator-upgrade_upgrade_red_hat_quay_on_openshift_container_platform[Preserving TLS settings before upgrading {productname-ocp}].
 
 [id="oidc-multi-issuer-config-fields-318"]
 == OIDC multi-issuer and multi-audience fields
@@ -28,7 +28,7 @@ The following optional fields were added to `*_LOGIN_CONFIG` blocks in {productn
 
 If both `OIDC_ISSUER` and `OIDC_ISSUERS` are set, `OIDC_ISSUERS` takes precedence and {productname} logs a warning.
 
-For field reference details, see xref:quay_jtbd-configure.adoc#oidc-config-fields[OIDC configuration fields]. For configuration examples, see xref:quay_jtbd-secure.adoc#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC].
+For field reference details, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#oidc-config-fields[OIDC configuration fields]. For configuration examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC].
 The following configuration fields have been added to {productname} 3.18.
 
 [id="quayregistry-tls-secretref"]
@@ -54,7 +54,7 @@ The following fields apply to the `tls` entry in `spec.components` of the `QuayR
 |`ComponentTLSReady` |Status | Reports whether TLS from the configured source (external Secret or config bundle) is valid and applied to the registry deployment.
 |===
 
-For procedures and examples, see xref:quay_jtbd-secure.adoc#operator-external-tls-secret-reference[Referencing an external TLS Secret for {productname-ocp}].
+For procedures and examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-external-tls-secret-reference[Referencing an external TLS Secret for {productname-ocp}].
 
 [id="programmatic-bootstrap-config-fields-318"]
 == Programmatic bootstrap configuration fields
@@ -74,4 +74,4 @@ For procedures and examples, see xref:quay_jtbd-secure.adoc#operator-external-tl
 |`PROGRAMMATIC_TOKEN_K8S_NAMESPACE` |String |Namespace for the bootstrap token Secret.
 |===
 
-For descriptions and YAML examples, see xref:quay_jtbd-configure.adoc#config-fields-programmatic-bootstrap[Programmatic bootstrap configuration fields].
+For descriptions and YAML examples, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-programmatic-bootstrap[Programmatic bootstrap configuration fields].

--- a/modules/oidc-config-fields.adoc
+++ b/modules/oidc-config-fields.adoc
@@ -98,8 +98,8 @@ AUTHENTICATION_TYPE: OIDC
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-secure.adoc#configuring-entra-oidc[Configuring OIDC for {productname}]
-* xref:quay_jtbd-secure.adoc#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-oidc[Configuring OIDC for {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-v2-multi-issuer-oidc[Configuring Microsoft Entra ID v2 and multi-issuer OIDC]
 
 .OIDC example YAML for Microsoft Entra ID v2 with dual-issuer support
 [source,yaml]

--- a/modules/operator-config-bundle-secret.adoc
+++ b/modules/operator-config-bundle-secret.adoc
@@ -66,5 +66,5 @@ Similarly, if you are managing the `horizontalpodautoscaler` component, you must
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-optimize.adoc#operator-hpa-overview[Disabling the horizontal pod autoscaler]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index#operator-hpa-overview[Disabling the horizontal pod autoscaler]
 endif::[]

--- a/modules/operator-config-cli.adoc
+++ b/modules/operator-config-cli.adoc
@@ -19,6 +19,6 @@ To enable features for your {productname} registry, you can edit the `configBund
 
 . On the *Secret details* page, click *Actions* -> *Edit secret*.
 
-. In the *Value* text box, add the new configuration fields for the features that you want to enable. For a list of all configuration fields, see xref:quay_jtbd-configure.adoc[Configure {productname}].
+. In the *Value* text box, add the new configuration fields for the features that you want to enable. For a list of all configuration fields, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index[Configure {productname}].
 
 . Click *Save*. The {productname} Operator automatically reconciles the changes by restarting all Quay-related pods. After all pods are restarted, the features are enabled.

--- a/modules/operator-external-tls-secret-reference.adoc
+++ b/modules/operator-external-tls-secret-reference.adoc
@@ -99,4 +99,4 @@ Substitute `my-quay-tls` with the name in `secretRef`. Wait for reconciliation a
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-whats_new.adoc#quayregistry-tls-secretref[QuayRegistry TLS component fields in the {productname} 3.18 release notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/release_notes/index#quayregistry-tls-secretref[QuayRegistry TLS component fields in the {productname} 3.18 release notes]

--- a/modules/operator-managed-postgres-tls-troubleshooting.adoc
+++ b/modules/operator-managed-postgres-tls-troubleshooting.adoc
@@ -16,4 +16,4 @@ On {ocp}, if the Service CA serving certificate Secret has not yet been created,
 
 If `SHOW ssl;` returns `on` but `pg_stat_ssl` shows no TLS client sessions, PostgreSQL is accepting encrypted connections, but {productname} or Clair might still be connecting without SSL. Check the registry configuration for an `sslmode` value on the database URI or connection arguments, and review Operator Events for certificate or CA problems.
 
-For external PostgreSQL databases, continue to configure TLS through `DB_URI` and related configuration fields in the config bundle. For more information, see xref:quay_jtbd-configure.adoc#config-fields-db[Database configuration fields].
+For external PostgreSQL databases, continue to configure TLS through `DB_URI` and related configuration fields in the config bundle. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-db[Database configuration fields].

--- a/modules/operator-unmanaged-redis.adoc
+++ b/modules/operator-unmanaged-redis.adoc
@@ -58,6 +58,6 @@ If both the `BUILDLOGS_REDIS` and `USER_EVENTS_REDIS` fields reference the same 
 For large or high-throughput registries, use separate Redis databases or clusters for these components.
 ====
 
-. Optional: Add additional database configuration fields, such as `DB_CONNECTION_ARGS` or SSL/TLS connection arguments. For more information, see xref:quay_jtbd-configure.adoc#config-fields-redis[Redis configuration fields].
+. Optional: Add additional database configuration fields, such as `DB_CONNECTION_ARGS` or SSL/TLS connection arguments. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-redis[Redis configuration fields].
 
 . Click *Save*.

--- a/modules/operator-unmanaged-storage.adoc
+++ b/modules/operator-unmanaged-storage.adoc
@@ -21,4 +21,4 @@ on-premises object storage providers:
 
 For a complete list of object storage providers, the link:https://access.redhat.com/articles/4067991[Quay Enterprise 3.x support matrix].
 
-For example configurations of external object storage, see xref:quay_jtbd-configure.adoc#config-fields-storage[Storage object configuration fields], which provides the required YAML configuration examples, credential formatting, and full field descriptions for all supported external storage providers.
+For example configurations of external object storage, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-storage[Storage object configuration fields], which provides the required YAML configuration examples, credential formatting, and full field descriptions for all supported external storage providers.

--- a/modules/optional-enabling-read-only-mode-backup-restore-ocp.adoc
+++ b/modules/optional-enabling-read-only-mode-backup-restore-ocp.adoc
@@ -37,4 +37,4 @@ You must meet the following prerequisites to enable read-only mode for {productn
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-configure.adoc#config-fields-web-ui[Miscellaneous configuration fields]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-web-ui[Miscellaneous configuration fields]

--- a/modules/preserving-tls-settings-operator-upgrade.adoc
+++ b/modules/preserving-tls-settings-operator-upgrade.adoc
@@ -52,6 +52,6 @@ $ oc create secret generic <config_bundle_secret_name> \
   --dry-run=client -o yaml | oc apply -f -
 ----
 +
-For more information, see xref:quay_jtbd-configure.adoc#modifying-configuration-file-ocp[Modifying the configuration file by using the {ocp} web console] and xref:quay_jtbd-secure.adoc#operator-ocp-tls-security-profile[Overriding the cluster TLS security profile].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#modifying-configuration-file-ocp[Modifying the configuration file by using the {ocp} web console] and link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-ocp-tls-security-profile[Overriding the cluster TLS security profile].
 
 . Proceed with the {productname} Operator upgrade. If the cluster TLS profile is acceptable and neither `SSL_PROTOCOLS` nor `SSL_CIPHERS` is set, no additional TLS configuration is required.

--- a/modules/proc_deploy_quay_guided.adoc
+++ b/modules/proc_deploy_quay_guided.adoc
@@ -64,15 +64,15 @@ where:
 
 . Configure additional registry settings as needed. The following fields are commonly updated for production high availability deployments:
 +
-* **TLS certificates**: Place `ssl.cert` and `ssl.key` in `/mnt/quay/config` and set `PREFERRED_URL_SCHEME: https`. See xref:quay_jtbd-secure.adoc#ssl-tls-quay-overview[Using SSL to protect connections to {productname}].
+* **TLS certificates**: Place `ssl.cert` and `ssl.key` in `/mnt/quay/config` and set `PREFERRED_URL_SCHEME: https`. See link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#ssl-tls-quay-overview[Using SSL to protect connections to {productname}].
 +
 [IMPORTANT]
 ====
 Using SSL certificates is recommended for production deployments. If you do not use SSL, configure your container clients to treat the registry as an insecure registry, as described in link:https://docs.docker.com/registry/insecure/[Test an Insecure Registry].
 ====
 +
-* **Clair image scanning**: Configure security scanner settings before enabling Clair. See xref:quay_jtbd-configure.adoc#clair-vulnerability-scanner[Clair Security Scanning].
-* **Repository mirroring**: Set `FEATURE_REPO_MIRROR: true` and related fields in `config.yaml`. See xref:quay_jtbd-integrate.adoc#enabling-repository-mirroring-quay[Enabling repository mirroring for {productname}].
-* **Action log storage, authentication, and access control**: See xref:quay_jtbd-configure.adoc[Configure {productname}] for the complete list of supported configuration fields.
+* **Clair image scanning**: Configure security scanner settings before enabling Clair. See link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#clair-vulnerability-scanner[Clair Security Scanning].
+* **Repository mirroring**: Set `FEATURE_REPO_MIRROR: true` and related fields in `config.yaml`. See link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#enabling-repository-mirroring-quay[Enabling repository mirroring for {productname}].
+* **Action log storage, authentication, and access control**: See link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index[Configure {productname}] for the complete list of supported configuration fields.
 
 . Copy the configuration directory, including `config.yaml` and any TLS certificate files, to each {productname} node in the cluster, for example `quay02` and `quay03`.

--- a/modules/proc_manage-advanced-config.adoc
+++ b/modules/proc_manage-advanced-config.adoc
@@ -12,7 +12,7 @@ After you deploy {productname}, you can change advanced settings by editing the 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-reference.adoc[{productname} API Guide]
-* xref:quay_jtbd-configure.adoc[{productname} configuration guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index[{productname} API Guide]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index[{productname} configuration guide]
 * link:https://www.postgresql.org/docs/current/libpq-connect.html[Database Connection Control Functions]
 * link:https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html[Connecting to the Server Using URI-Like Strings or Key-Value Pairs]

--- a/modules/quay-feature-tracker.adoc
+++ b/modules/quay-feature-tracker.adoc
@@ -14,32 +14,32 @@ Some features available in previous releases have been deprecated or removed. De
 |===
 |Feature | Quay 3.18 | Quay 3.17 | Quay 3.16
 
-|xref:quay_jtbd-secure.adoc#configuring-entra-v2-multi-issuer-oidc[Microsoft Entra ID v2 token and multi-issuer OIDC support]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-v2-multi-issuer-oidc[Microsoft Entra ID v2 token and multi-issuer OIDC support]
 |General Availability
 |-
 |-
 
-|xref:quay_jtbd-administer.adoc#programmatic-oauth-token-provisioning[Programmatic OAuth token provisioning]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#programmatic-oauth-token-provisioning[Programmatic OAuth token provisioning]
 |Technology Preview
 |-
 |-
 
-|xref:quay_jtbd-secure.adoc#operator-ocp-tls-security-profile[OpenShift Container Platform cluster TLS security profile inheritance & Post-Quantum Cryptography (PQC) readiness]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/securing_red_hat_quay/index#operator-ocp-tls-security-profile[OpenShift Container Platform cluster TLS security profile inheritance & Post-Quantum Cryptography (PQC) readiness]
 |General Availability
 |-
 |-
 
-|xref:quay_jtbd-integrate.adoc#arch-mirroring-intro[Sparse manifest support for multi-architecture filtering]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index#arch-mirroring-intro[Sparse manifest support for multi-architecture filtering]
 |General Availability
 |General Availability
 |-
 
-|xref:quay_jtbd-administer.adoc#immutable-tag-overview[Immutable tags overview]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#immutable-tag-overview[Immutable tags overview]
 |General Availability
 |General Availability
 |-
 
-|xref:quay_jtbd-secure.adoc#configuring-entra-oidc[Proof Key for Code Exchange support for OIDC]
+|link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#configuring-entra-oidc[Proof Key for Code Exchange support for OIDC]
 |General Availability
 |General Availability
 |-

--- a/modules/quota-management-arch.adoc
+++ b/modules/quota-management-arch.adoc
@@ -35,4 +35,4 @@ Image manifest deletion follows a similar flow, whereby the links between associ
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-administer.adoc#garbage-collection[{productname} garbage collection]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/manage_red_hat_quay/index#garbage-collection[{productname} garbage collection]

--- a/modules/quota-proxy-configuration-overview.adoc
+++ b/modules/quota-proxy-configuration-overview.adoc
@@ -16,5 +16,5 @@ Collectively, these capabilities ensure better performance, governance, and resi
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-administer.adoc#red-hat-quay-quota-management-and-enforcement[Quota management and enforcement]
-* xref:quay_jtbd-integrate.adoc#quay-as-cache-proxy[Proxy cache for upstream registries]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/use_red_hat_quay/index#red-hat-quay-quota-management-and-enforcement[Quota management and enforcement]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index#quay-as-cache-proxy[Proxy cache for upstream registries]

--- a/modules/ref_quay-integration-config-fields.adoc
+++ b/modules/ref_quay-integration-config-fields.adoc
@@ -10,7 +10,7 @@
 The `QuayIntegration` custom resource enables integration between your {ocp} cluster and a {productname} registry instance.
 
 .Additional resources
-* xref:quay_jtbd-integrate.adoc#quay-bridge-operator-features[Integrating {productname} into {ocp} with the {qbo}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/managing_access_and_permissions/index#quay-bridge-operator-features[Integrating {productname} into {ocp} with the {qbo}]
 
 .QuayIntegration configuration fields
 [cols="4a,2a,2a",options="header"]

--- a/modules/registry-deploy-cli.adoc
+++ b/modules/registry-deploy-cli.adoc
@@ -9,7 +9,7 @@ To deploy a basic {productname} registry instance, you can use the `oc` CLI to c
 ====
 The following `config.yaml` file includes automation configuration options. Collectively, these options streamline using the CLI with your registry, helping reduce dependency on the UI. Adding these fields to your `config.yaml` file is optional if you plan to use the UI, but recommended if you plan to use the CLI. 
 
-For more information, see xref:quay_jtbd-configure.adoc#config-preconfigure-automation-intro[Automation configuration options].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-preconfigure-automation-intro[Automation configuration options].
 ====
 
 .Prerequisites

--- a/modules/registry-deploy-console.adoc
+++ b/modules/registry-deploy-console.adoc
@@ -59,7 +59,7 @@ DISTRIBUTED_STORAGE_CONFIG:
 +
 [NOTE]
 ====
-Depending on your storage provider, different information is required. For more information, see see xref:quay_jtbd-configure.adoc#config-fields-storage[Storage object configuration fields].
+Depending on your storage provider, different information is required. For more information, see see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/configure_red_hat_quay/index#config-fields-storage[Storage object configuration fields].
 ====
 
 .. Click *Save*, and then re-navigate to the *Events* page of the registry to ensure successful deployment.

--- a/modules/reverting-tag-changes-api.adoc
+++ b/modules/reverting-tag-changes-api.adoc
@@ -15,11 +15,11 @@ offers a comprehensive _time machine_ feature that allows older images tags to r
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. You can restore a repository tag to its previous image by using the xref:quay_jtbd-reference.adoc#restoretag[`POST /api/v1/repository/{repository}/tag/{tag}/restore`] command. For example:
+. You can restore a repository tag to its previous image by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#restoretag[`POST /api/v1/repository/{repository}/tag/{tag}/restore`] command. For example:
 +
 [source,terminal]
 ----
@@ -38,7 +38,7 @@ $ curl -X POST \
 {}
 ----
 
-. To see a list of tags after restoring an old tag you can use the xref:quay_jtbd-reference.adoc#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
+. To see a list of tags after restoring an old tag you can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command. For example:
 +
 [source,terminal]
 ----

--- a/modules/rn-intro.adoc
+++ b/modules/rn-intro.adoc
@@ -32,7 +32,7 @@ endif::downstream[]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:quay_jtbd-upgrade.adoc[Upgrade {productname}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/upgrade_red_hat_quay/index[Upgrade {productname}]
 ifdef::downstream[]
-* xref:quay_jtbd-discover.adoc[{productname} Documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_architecture/index[{productname} Documentation]
 endif::downstream[]

--- a/modules/setting-quota-api.adoc
+++ b/modules/setting-quota-api.adoc
@@ -7,7 +7,7 @@ To create, view, or update an organization storage quota in {productname}, you c
 
 .Procedure
 
-. To set a quota for an organization, you can use the xref:quay_jtbd-reference.adoc#createorganizationquota[`POST /api/v1/organization/{orgname}/quota`] endpoint:
+. To set a quota for an organization, you can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#createorganizationquota[`POST /api/v1/organization/{orgname}/quota`] endpoint:
 +
 [source,terminal]
 ----
@@ -26,7 +26,7 @@ $ curl -X POST "https://<quay-server.example.com>/api/v1/organization/<orgname>/
 "Created"
 ----
 
-. Use the xref:quay_jtbd-reference.adoc#listorganizationquota[`GET /api/v1/organization/{orgname}/quota`] command to see if your organization already has an established quota:
+. Use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listorganizationquota[`GET /api/v1/organization/{orgname}/quota`] command to see if your organization already has an established quota:
 +
 [source,terminal]
 ----
@@ -39,7 +39,7 @@ $ curl -k -X GET -H "Authorization: Bearer <token>" -H 'Content-Type: applicatio
 [{"id": 1, "limit_bytes": 10737418240, "limit": "10.0 GiB", "default_config": false, "limits": [], "default_config_exists": false}]
 ----
 
-. You can use the xref:quay_jtbd-reference.adoc#changeorganizationquota[`PUT /api/v1/organization/{orgname}/quota/{quota_id}`] command to modify the existing quota limitation. For example:
+. You can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#changeorganizationquota[`PUT /api/v1/organization/{orgname}/quota/{quota_id}`] command to modify the existing quota limitation. For example:
 +
 [source,terminal]
 ----

--- a/modules/setting-tag-expiration-api.adoc
+++ b/modules/setting-tag-expiration-api.adoc
@@ -7,11 +7,11 @@ To set when an image tag expires in {productname}, you can use the API.
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-* You can set when an image a tag expires by using the xref:quay_jtbd-reference.adoc#changetag[`PUT /api/v1/repository/{repository}/tag/{tag}`] command and passing in the expiration field:
+* You can set when an image a tag expires by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#changetag[`PUT /api/v1/repository/{repository}/tag/{tag}`] command and passing in the expiration field:
 +
 [source,terminal]
 ----

--- a/modules/upgrading-geo-repl-quay-operator.adoc
+++ b/modules/upgrading-geo-repl-quay-operator.adoc
@@ -69,7 +69,7 @@ quayregistry-quay-app-upgrade-xq2v6                0/1     Completed   0        
 quayregistry-quay-redis-84f888776f-hhgms           1/1     Running     0             12m
 ----
 
-. On System A, initiate a {productname} upgrade to the latest y-stream version. This is a manual process. For more information about upgrading installed Operators, see link:https://docs.openshift.com/container-platform/4.22/operators/admin/olm-upgrading-operators.html[Upgrading installed Operators]. For more information about {productname} upgrade paths, see xref:quay_jtbd-upgrade.adoc#operator-upgrade[Upgrading the {productname} Operator].
+. On System A, initiate a {productname} upgrade to the latest y-stream version. This is a manual process. For more information about upgrading installed Operators, see link:https://docs.openshift.com/container-platform/4.22/operators/admin/olm-upgrading-operators.html[Upgrading installed Operators]. For more information about {productname} upgrade paths, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/upgrade_red_hat_quay/index#operator-upgrade[Upgrading the {productname} Operator].
 
 . After the new {productname} registry is installed, the necessary upgrades on the cluster are automatically completed. Afterwards, new {productname} pods are started with the latest y-stream version. Additionally, new `Quay` pods are scheduled and started.
 

--- a/modules/upgrading-geo-repl-quay.adoc
+++ b/modules/upgrading-geo-repl-quay.adoc
@@ -14,7 +14,7 @@ To upgrade a geo-replication deployment of standalone {productname}, stop operat
 
 [NOTE]
 ====
-This procedure assumes that you are running {productname} services on three (or more) systems. For more information, see xref:quay_jtbd-plan.adoc#preparing-for-quay-ha[Preparing for {productname} high availability].
+This procedure assumes that you are running {productname} services on three (or more) systems. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/deploy_red_hat_quay_-_high_availability/index#preparing-for-quay-ha[Preparing for {productname} high availability].
 ====
 
 

--- a/modules/viewing-tag-history-v2-api.adoc
+++ b/modules/viewing-tag-history-v2-api.adoc
@@ -7,11 +7,11 @@ To review the history of image tags in a {productname} repository, you can use t
 
 .Prerequisites
 
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure
 
-. Enter the following command to view tag history by using the xref:quay_jtbd-reference.adoc#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command and passing in one of the following queries:
+. Enter the following command to view tag history by using the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepotags[`GET /api/v1/repository/{repository}/tag/`] command and passing in one of the following queries:
 +
 * *onlyActiveTags=<true/false>*: Filters to only include active tags.
 

--- a/modules/viewing-tags-api.adoc
+++ b/modules/viewing-tags-api.adoc
@@ -8,11 +8,11 @@ To view image tag details for a repository in {productname}, you can use the API
 .Prerequisites
 
 * You have pushed an image tag to a {productname} repository.
-* You have xref:quay_jtbd-develop.adoc#creating-oauth-access-token[Created an OAuth access token].
+* You have link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_guide/index#creating-oauth-access-token[Created an OAuth access token].
 
 .Procedure 
 
-. To obtain tag information, you must use the xref:quay_jtbd-reference.adoc#getrepo[`GET /api/v1/repository/{repository}`] API endpoint and pass in the `includeTags` parameter. For example:
+. To obtain tag information, you must use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#getrepo[`GET /api/v1/repository/{repository}`] API endpoint and pass in the `includeTags` parameter. For example:
 +
 [source,terminal]
 ----
@@ -28,7 +28,7 @@ $ curl -X GET \
 {"namespace": "quayadmin", "name": "busybox", "kind": "image", "description": null, "is_public": false, "is_organization": false, "is_starred": false, "status_token": "d8f5e074-690a-46d7-83c8-8d4e3d3d0715", "trust_enabled": false, "tag_expiration_s": 1209600, "is_free_account": true, "state": "NORMAL", "tags": {"example": {"name": "example", "size": 2275314, "last_modified": "Tue, 14 May 2024 14:48:51 -0000", "manifest_digest": "sha256:57583a1b9c0a7509d3417387b4f43acf80d08cdcf5266ac87987be3f8f919d5d"}, "test": {"name": "test", "size": 2275314, "last_modified": "Tue, 14 May 2024 14:04:48 -0000", "manifest_digest": "sha256:57583a1b9c0a7509d3417387b4f43acf80d08cdcf5266ac87987be3f8f919d5d"}}, "can_write": true, "can_admin": true}
 ----
 
-. Alternatively, you can use the xref:quay_jtbd-reference.adoc#listrepotags[`GET /api/v1/repository/{repository}/tag/`] endpoint. For example:
+. Alternatively, you can use the link:https://docs.redhat.com/en/documentation/red_hat_quay/3.18/html-single/red_hat_quay_api_reference/index#listrepotags[`GET /api/v1/repository/{repository}/tag/`] endpoint. For example:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
## Summary
- Apply the same Pantheon rule as builders: keep `xref:` only when the target ID is included in that book's `master.adoc`; otherwise use a published `link:`.
- Convert 152 out-of-book xrefs across Configure, Deploy HA, Deploy on OCP, Manage Quay, Access and permissions, API reference, Architecture, Operator features, Release notes, Securing, Troubleshooting, Upgrading, and Use Red Hat Quay.
- Hardcode `3.18` in link URLs because AEM does not substitute attributes in `link:` targets.

## Test plan
- [ ] Rebuild each listed title on Pantheon and confirm unknown-ID xref errors are gone.
- [ ] Spot-check that remaining `xref:`s still resolve inside the same assembly.
- [ ] Spot-check a few converted links (SSL/TLS, API reference, Architecture, Clair) open the intended 3.18 topics.


Made with [Cursor](https://cursor.com)