### PR TITLE
Adds 3.10.26 release notes

### DIFF
--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -17,7 +17,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.10
-:productminv: v3.10.25
+:productminv: v3.10.26
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -33,8 +33,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.10
-:productmin: 3.10.25
-:productminv: v3.10.25
+:productmin: 3.10.26
+:productminv: v3.10.26
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -5,6 +5,13 @@
 The following sections detail _y_ and _z_ stream release information.
 
 
+[id="rn-3-10-26"]
+== RHSA-TBD - {productname} 3.10.26 release
+
+Issued 2026-09-09
+
+{productname} release 3.10.26 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory.
+
 [id="rn-3-10-25"]
 == RHSA-2026:53520 - {productname} 3.10.25 release
 

--- a/modules/rn_3_10.adoc
+++ b/modules/rn_3_10.adoc
@@ -6,11 +6,11 @@ The following sections detail _y_ and _z_ stream release information.
 
 
 [id="rn-3-10-26"]
-== RHSA-TBD - {productname} 3.10.26 release
+== RHSA-2026:66084 - {productname} 3.10.26 release
 
 Issued 2026-09-09
 
-{productname} release 3.10.26 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/[RHSA-TBD] advisory.
+{productname} release 3.10.26 is now available with Clair {clairproductminv}. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:66084[RHSA-2026:66084] advisory.
 
 [id="rn-3-10-25"]
 == RHSA-2026:53520 - {productname} 3.10.25 release


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for Red Hat Quay 3.10.26
- Source: https://github.com/quay/quay-konflux-configs/pull/274
- Jira: https://redhat.atlassian.net/browse/PROJQUAY-13159

## Skipped (not documented)
All twenty-four fixed issues are CVE-only. Advisory-only entry per 3.10 y-stream convention.

## Manual follow-up before merge
- **Errata not yet published** on access.redhat.com as of 2026-09-09. Replace `RHSA-TBD` and the errata link in `modules/rn_3_10.adoc` with the real advisory ID and confirm the issued date when RHSA is live.

## Test plan
- [ ] Advisory ID and issued date match access.redhat.com errata (update from RHSA-TBD)
- [ ] Attributes updated to 3.10.26
- [ ] Bug bullets exclude CVE-only, Red Hat Employee, Restricted, and other internal-only tickets
- [ ] Vale / AsciiDoc build clean on redhat-3.10


Made with [Cursor](https://cursor.com)