### PR TITLE
Publish JTBD multipage navigation preview to GitHub Pages

### DIFF
--- a/.github/workflows/jtbd-multipage-preview.yml
+++ b/.github/workflows/jtbd-multipage-preview.yml
@@ -53,10 +53,13 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
+      - name: Install gems
+        run: bundle install
+
       - name: Build multipage JTBD preview
         run: |
           mkdir -p build/jtbd
-          asciidoctor -r asciidoctor-multipage -b multipage_html5 \
+          bundle exec asciidoctor -r asciidoctor-multipage -b multipage_html5 \
             quay-3-18-navigation.adoc \
             -D build/jtbd \
             -a toc=left \

--- a/.github/workflows/jtbd-multipage-preview.yml
+++ b/.github/workflows/jtbd-multipage-preview.yml
@@ -13,7 +13,10 @@ on:
       - 'Gemfile'
       - 'Gemfile.lock'
       - '.github/workflows/jtbd-multipage-preview.yml'
-  pull_request:
+  # pull_request_target runs in the base repo with write access so fork PRs
+  # can publish previews to gh-pages (pull_request gives a read-only token).
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     branches: [master]
     paths: *jtbd-paths
   workflow_dispatch:
@@ -32,11 +35,13 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set preview path
         id: preview
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             PREVIEW_DIR="pr-${{ github.event.pull_request.number }}"
           elif [ "${{ github.ref_name }}" = "master" ]; then
             PREVIEW_DIR="master"
@@ -73,6 +78,7 @@ jobs:
         with:
           ref: gh-pages
           path: pages
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to gh-pages
         id: publish
@@ -98,7 +104,6 @@ jobs:
           </html>
           EOF
 
-          # Root index listing all preview branches/PRs.
           {
             echo '<!DOCTYPE html>'
             echo '<html lang="en"><head><meta charset="utf-8"><title>Quay docs JTBD previews</title>'
@@ -106,6 +111,9 @@ jobs:
             echo '</head><body><h1>Quay docs JTBD previews</h1><ul>'
             for dir in pages/*/; do
               name=$(basename "$dir")
+              [ "$name" = "assets" ] && continue
+              [ "$name" = "api-v2" ] && continue
+              [ "$name" = "search" ] && continue
               echo "    <li><a href=\"${name}/jtbd/quay-3-18-navigation.html\">${name}</a></li>"
             done
             echo '  </ul></body></html>'
@@ -125,7 +133,7 @@ jobs:
           fi
 
       - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request' && steps.publish.outputs.changed == 'true'
+        if: github.event_name == 'pull_request_target' && steps.publish.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/jtbd-multipage-preview.yml
+++ b/.github/workflows/jtbd-multipage-preview.yml
@@ -13,8 +13,11 @@ on:
       - 'Gemfile'
       - 'Gemfile.lock'
       - '.github/workflows/jtbd-multipage-preview.yml'
-  # pull_request_target runs in the base repo with write access so fork PRs
-  # can publish previews to gh-pages (pull_request gives a read-only token).
+  pull_request:
+    branches: [master]
+    paths: *jtbd-paths
+  # Runs in the base repo with write access so fork PRs can publish to gh-pages.
+  # Requires this workflow file to exist on master (not only in the PR branch).
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [master]
@@ -30,7 +33,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install gems
+        run: bundle install
+
+      - name: Build multipage JTBD preview
+        run: |
+          mkdir -p build/jtbd
+          bundle exec asciidoctor -r asciidoctor-multipage -b multipage_html5 \
+            quay-3-18-navigation.adoc \
+            -D build/jtbd \
+            -a toc=left \
+            -a doctype=book \
+            -a toclevels=4 \
+            -a docinfo=shared-footer \
+            -a multipage-level=4
+
   publish:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Check out source

--- a/.github/workflows/jtbd-multipage-preview.yml
+++ b/.github/workflows/jtbd-multipage-preview.yml
@@ -1,0 +1,142 @@
+name: JTBD multipage preview
+
+on:
+  push:
+    branches: [master]
+    paths: &jtbd-paths
+      - 'quay-3-18-navigation.adoc'
+      - 'quay_jtbd/**'
+      - '_attributes/**'
+      - 'modules/**'
+      - 'images/**'
+      - 'docinfo-footer.html'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.github/workflows/jtbd-multipage-preview.yml'
+  pull_request:
+    branches: [master]
+    paths: *jtbd-paths
+  workflow_dispatch:
+
+concurrency:
+  group: gh-pages-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set preview path
+        id: preview
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PREVIEW_DIR="pr-${{ github.event.pull_request.number }}"
+          elif [ "${{ github.ref_name }}" = "master" ]; then
+            PREVIEW_DIR="master"
+          else
+            PREVIEW_DIR="${{ github.ref_name }}"
+          fi
+          PREVIEW_DIR="${PREVIEW_DIR//\//-}"
+          echo "dir=${PREVIEW_DIR}" >> "$GITHUB_OUTPUT"
+          echo "Publishing JTBD preview to gh-pages/${PREVIEW_DIR}/jtbd/"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build multipage JTBD preview
+        run: |
+          mkdir -p build/jtbd
+          asciidoctor -r asciidoctor-multipage -b multipage_html5 \
+            quay-3-18-navigation.adoc \
+            -D build/jtbd \
+            -a toc=left \
+            -a doctype=book \
+            -a toclevels=4 \
+            -a docinfo=shared-footer \
+            -a multipage-level=4
+
+      - name: Check out gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: pages
+
+      - name: Publish to gh-pages
+        id: publish
+        run: |
+          PREVIEW_DIR="${{ steps.preview.outputs.dir }}"
+          rm -rf "pages/${PREVIEW_DIR}/jtbd" "pages/${PREVIEW_DIR}/images"
+          mkdir -p "pages/${PREVIEW_DIR}/jtbd" "pages/${PREVIEW_DIR}/images"
+          cp -a build/jtbd/. "pages/${PREVIEW_DIR}/jtbd/"
+          cp -a images/. "pages/${PREVIEW_DIR}/images/"
+          touch pages/.nojekyll
+
+          cat > "pages/${PREVIEW_DIR}/jtbd/index.html" <<'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=quay-3-18-navigation.html">
+            <title>Red Hat Quay JTBD preview</title>
+          </head>
+          <body>
+            <p><a href="quay-3-18-navigation.html">Red Hat Quay JTBD navigation preview</a></p>
+          </body>
+          </html>
+          EOF
+
+          # Root index listing all preview branches/PRs.
+          {
+            echo '<!DOCTYPE html>'
+            echo '<html lang="en"><head><meta charset="utf-8"><title>Quay docs JTBD previews</title>'
+            echo '<style>body{font-family:sans-serif;max-width:720px;margin:40px auto;padding:0 20px} li{line-height:2}</style>'
+            echo '</head><body><h1>Quay docs JTBD previews</h1><ul>'
+            for dir in pages/*/; do
+              name=$(basename "$dir")
+              echo "    <li><a href=\"${name}/jtbd/quay-3-18-navigation.html\">${name}</a></li>"
+            done
+            echo '  </ul></body></html>'
+          } > pages/index.html
+
+          cd pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${PREVIEW_DIR}/jtbd" "${PREVIEW_DIR}/images" index.html .nojekyll
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No JTBD preview changes to publish."
+          else
+            git commit -m "JTBD multipage preview for ${PREVIEW_DIR}"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment PR with preview URL
+        if: github.event_name == 'pull_request' && steps.publish.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREVIEW_DIR="${{ steps.preview.outputs.dir }}"
+          PREVIEW_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${PREVIEW_DIR}/jtbd/quay-3-18-navigation.html"
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
+          ## JTBD navigation preview
+
+          Multipage HTML preview published to GitHub Pages:
+
+          **${PREVIEW_URL}**
+
+          Home page: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${PREVIEW_DIR}/jtbd/
+
+          Rebuilds automatically when JTBD-related files change on this PR.
+          EOF
+          )"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,13 +4,8 @@ name: ccutil-workflow
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
-  #pull_request:
-  #  branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Legacy ccutil html-single previews. JTBD multipage previews use
+  # .github/workflows/jtbd-multipage-preview.yml on push to master.
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist
 build/
 .DS_Store
 .idea/
+
+# Local asciidoctor-multipage output (CI publishes to gh-pages)
+/*.html
+!docinfo-footer.html

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'asciidoctor'
+gem 'asciidoctor-multipage', '~> 0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    asciidoctor (2.0.26)
+    asciidoctor-multipage (0.0.19)
+      asciidoctor (>= 2.0.11, < 2.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  asciidoctor
+  asciidoctor-multipage (~> 0.0)
+
+BUNDLED WITH
+   2.6.9

--- a/docinfo-footer.html
+++ b/docinfo-footer.html
@@ -1,0 +1,33 @@
+<style>
+ #toc ul li.has-children > ul {
+   display: none;
+ }
+ #toc ul li.has-children.open > ul {
+   display: block;
+ }
+ .toc-toggle {
+   cursor: pointer;
+   margin-right: 4px;
+   font-size: 0.75em;
+   user-select: none;
+ }
+</style>
+<script>
+ document.addEventListener('DOMContentLoaded', function() {
+   document.querySelectorAll('#toc li').forEach(function(li) {
+     var sublist = li.querySelector(':scope > ul');
+     if (sublist) {
+       li.classList.add('has-children');
+       var toggle = document.createElement('span');
+       toggle.className = 'toc-toggle';
+       toggle.textContent = '▶';
+       li.insertBefore(toggle, li.firstChild);
+       toggle.addEventListener('click', function() {
+         li.classList.toggle('open');
+         toggle.textContent = li.classList.contains('open') ? '▼' : '▶';
+       });
+     }
+   });
+ });
+</script>
+


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds `quay-3-18-navigation.adoc` with `asciidoctor-multipage` and publishes HTML to `gh-pages`
- **Master pushes** publish to `master/jtbd/` on GitHub Pages
- **Pull requests** publish to `pr-<number>/jtbd/` and post an automated comment with the preview URL
- Adds `asciidoctor-multipage` to the Gemfile and `docinfo-footer.html` for collapsible TOC
- Disables automatic runs of the legacy `ccutil-workflow` on master (manual only) to avoid `gh-pages` push conflicts

## Preview URLs (after merge + Pages deploy)
- Master: `https://quay.github.io/quay-docs/master/jtbd/quay-3-18-navigation.html`
- Index: `https://quay.github.io/quay-docs/`

## Prerequisites
- [ ] GitHub Pages enabled on `quay/quay-docs` (deploy from `gh-pages` branch, root)
- [ ] Actions workflow permissions: **Read and write** (Settings → Actions → General)

## Test plan
- [ ] Workflow runs on this PR and posts a preview URL comment
- [ ] Preview pages render with left TOC and navigation links
- [ ] Images load from `../images/` paths
- [ ] Master merge updates `master/jtbd/` on `gh-pages`


Made with [Cursor](https://cursor.com)