### PR TITLE
Backport #1812: resolve documentation example secret false positives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist
 build/
 .DS_Store
 .idea/
+# Local multipage HTML previews (source is .adoc)
+/*.html
+!docinfo-footer.html

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,62 @@
+[allowlist]
+  description = "Documentation examples, bcrypt hashes, and generated HTML preview artifacts"
+
+  regexes = [
+    # Ignore bcrypt password hashes (e.g., $2b$12$...)
+    '''\$2b\$12\$[A-Za-z0-9./]{53}''',
+
+    # Obvious documentation placeholders in API and config examples.
+    '''"client_secret":\s*"<client_secret>"''',
+    '''"client_id":\s*"<client_id>"''',
+    '''SERVICE_ACCOUNT_TOKEN:\s*"<sample_account_token>"''',
+    '''"password":\s*"<new_password>"''',
+    '''client_secret=<client_secret>''',
+    '''<sample_account_token>''',
+    '''<client_secret>''',
+    '''<new_password>''',
+    '''EXAMPLE_''',
+
+    # Historical doc example values (pre-placeholder cleanup).
+    '''ANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
+    '''E6GJSHOZMFBVNHTHNB53''',
+    '''MCJ61D8KQBFS2DXM56S2''',
+    '''J5G7CCX5QCA8Q5XZLWGI7USJPSM4M5MQHJED46CF''',
+    '''IG58PX2REEY9O08IZFZE''',
+    '''2LWTWO89KH26P2CO4TWFM7PGCX4V4SUZES2CIZMR''',
+    '''6XBK7QY7ACSCN5XBM3GS''',
+    '''AVKBOUXTFO3MXBBK5UJD5QCQRN2FWL3O0XPZZT78''',
+    '''SANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
+    '''WB4FUG4PP2278KK579EN4NDP150CPYOG6DN42MP6JF8IAJ4PON4RC7DIOH5UEFBP''',
+    '''MXFE7NSOWPN33O7UC3THY0BN03DW940CMWTLRBE2EPTI8JPX0B0CWIIDGTI4YTJ6''',
+    '''IJWZ8TIY301KPFOW3WEUJEVZ3JR11CY1''',
+    '''9Q36xF54YEOLjetayC0NBaIKgcFFmIHsS3xTZDLzZSrhTBkxUc9FDwUKfnxLWhco6oBJV1NDBjoBcDGmsZMYPt1dSA4yWpPe/JKY9pnDcsw=''',
+    '''MXZ9DATUWRD8WCMT8AZIPYE0IEZHJJ1B8P8ZEIXC0W552DUMMTNJJH02HFGXTOVG''',
+    '''CWLBVAODE61IXNDJ40GERFOZPB3ARZDRCP4X70ID1NB28AI0OOJBTR9S4M0ACYMD''',
+    '''BILZ6YTVAZAKOGMD9270OKN3SOD9KPB7OLKEJQOJE38NBBRUJTIH7T5859DJL31Q''',
+    '''QBFYWIWZOS1I0P0R9N1JRNP1UZAOPUIR3EB4ASPZKK9IA1SFC12LTEF7OJHB05Z8''',
+    '''postgresql://<username>:test123@172.24.10.50/quay''',
+    '''postgresql://<username>:test123@172.24.10.50/example-restore-registry-quay-database''',
+    '''postgresql://quayuser:quaypass@quay-server:5432/quay''',
+    '''4b1c5663-88c6-47ac-b4a8-bb594660f08b''',
+    '''postgresql://example-registry-quay-database:OyC4zGhJMbi3yUzW1aIgOLQNW18r14nAcuJfbsjtrAXUVInj2JgwLskQPOutPCXMtlKr1UPTsIPqOEjV@example-registry-quay-database:5432/example-registry-quay-database''',
+    '''postgresql://restore-registry-quay-database:zLTm315muk6rz7mL4aFuLQ2Q8rAk-dB4kPHQ2WMvdyqhaZywf20503wCZfv2Ml1f15LUsDN2-0m71gnI@restore-registry-quay-database:5432/restore-registry-quay-database''',
+    '''postgresql://example-restore-registry-quay-database:onHl1LDsspZh4hoOL5wW1Of7GV0Kmtp2@example-restore-registry-quay-database:5432/example-restore-registry-quay-database''',
+    '''zsk/j4zEOkQq+W0BQJdSufP+IackV8WICXB5zvdF''',
+    '''1H36Izzc90cUNVHaiaUX''',
+    '''iO1b3RUt4KKgjSimCROSPN3cEMn4TqSgsPyniMBR''',
+    '''EH67NB3Y6PTBED8H0HC6UVHGGGA3ODSE''',
+    '''fn37AZAUQH0PTsU\+vlO9lS0QxPW9A/boXL4ovZjIFtlUPrBz9i4j9UDOqMjuxQ/0HTfy38goKEpG8zYXVeQh3lOFzuOjSvKic2Vq7xdtQsU=''',
+    '''XyThQKm6lMWh4O7dKdmRwMUHB9ktxPPVSRIePOY2''',
+    '''VvoFhVFp8BqcOgQ9LczE''',
+    '''g8gPsBLxVrLo2PjmZkYBdKvcB9C7fmBz''',
+    '''eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ''',
+    '''N3wP@ssw0rd''',
+  ]
+
+  paths = [
+    '''\/example.*\.pem$''',
+
+    # Multipage HTML previews committed briefly during local doc builds.
+    '''^[a-z0-9_-]+\.html$''',
+    '''^_[a-z0-9_-]+\.html$''',
+  ]

--- a/modules/attributes.adoc
+++ b/modules/attributes.adoc
@@ -15,7 +15,7 @@ ifeval::["{productname}" == "Project Quay"]
 :productname: Project Quay
 :productversion: 3
 :producty: 3.9
-:productminv: v3.9.25
+:productminv: v3.9.26
 :productrepo: quay.io/projectquay
 :quayimage: quay
 :clairimage: clair
@@ -31,8 +31,8 @@ ifeval::["{productname}" == "Red Hat Quay"]
 :productname: Red Hat Quay
 :productversion: 3
 :producty: 3.9
-:productmin: 3.9.25
-:productminv: v3.9.25
+:productmin: 3.9.26
+:productminv: v3.9.26
 :productrepo: registry.redhat.io/quay
 :quayimage: quay-rhel8
 :clairimage: clair-rhel8

--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -97,7 +97,7 @@ $ oc create token quay-builder -n virtual-builders
 .Example output
 [source,terminal]
 ----
-eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ...
+<sample_account_token>...
 ----
 
 . Determine the builder route by entering the following command:
@@ -233,7 +233,7 @@ BUILD_MANAGER:
         NODE_SELECTOR_LABEL_KEY: ""
         NODE_SELECTOR_LABEL_VALUE: ""
         SERVICE_ACCOUNT_NAME: quay-builder
-        SERVICE_ACCOUNT_TOKEN: "eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ"
+        SERVICE_ACCOUNT_TOKEN: "<sample_account_token>"
 ----
 
 [id="red-hat-quay-manual-ssl-for-builders"]

--- a/modules/rn_3_90.adoc
+++ b/modules/rn_3_90.adoc
@@ -6,6 +6,13 @@
 The following sections detail _y_ and _z_ stream release information.
 
 
+[id="rn-3-9026"]
+== RHSA-2026:65514 - {productname} 3.9.26 release
+
+Issued 2026-09-08
+
+{productname} release 3.9.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2026:65514[RHSA-2026:65514] advisory.
+
 [id="rn-3-9025"]
 == RHSA-2026:50931 - {productname} 3.9.25 release
 


### PR DESCRIPTION
## Summary
Backport of https://github.com/quay/quay-docs/pull/1812 to `redhat-3.9`.

- Replace realistic-looking OAuth, JWT, and password placeholders in documentation examples with obvious placeholders.
- Update `.gitleaks.toml` allowlist for documentation examples and generated HTML preview artifacts.
- Ignore local root-level `*.html` preview output in `.gitignore`.

## Test plan
- [ ] Verify only applicable modules for this release branch were updated
- [ ] Confirm rendered examples still read clearly with placeholder values


Made with [Cursor](https://cursor.com)