### PR TITLE
Backport #1812: resolve documentation example secret false positives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist
 build/
 .DS_Store
 .idea/
+# Local multipage HTML previews (source is .adoc)
+/*.html
+!docinfo-footer.html

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,54 +1,62 @@
 [allowlist]
-description = "Allow bcrypt hashes used in SQL updates"
+  description = "Documentation examples, bcrypt hashes, and generated HTML preview artifacts"
 
-regexes = [
-  # Ignore bcrypt password hashes (e.g., $2b$12$...)
-  '''\$2b\$12\$[A-Za-z0-9./]{53}'''
-]
+  regexes = [
+    # Ignore bcrypt password hashes (e.g., $2b$12$...)
+    '''\$2b\$12\$[A-Za-z0-9./]{53}''',
 
-paths = [
-  # Ignore all example certs
-  '''\/example.*\.pem$''',
+    # Obvious documentation placeholders in API and config examples.
+    '''"client_secret":\s*"<client_secret>"''',
+    '''"client_id":\s*"<client_id>"''',
+    '''SERVICE_ACCOUNT_TOKEN:\s*"<sample_account_token>"''',
+    '''"password":\s*"<new_password>"''',
+    '''client_secret=<client_secret>''',
+    '''<sample_account_token>''',
+    '''<client_secret>''',
+    '''<new_password>''',
+    '''EXAMPLE_''',
 
-  # Ignore anything with the word funkymonkey anywhere in the path (example values below)
-  '''ANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
-  '''E6GJSHOZMFBVNHTHNB53''',
-  '''MCJ61D8KQBFS2DXM56S2''',
-  '''J5G7CCX5QCA8Q5XZLWGI7USJPSM4M5MQHJED46CF''',
-  '''IG58PX2REEY9O08IZFZE''',
-  '''2LWTWO89KH26P2CO4TWFM7PGCX4V4SUZES2CIZMR''',
-  '''6XBK7QY7ACSCN5XBM3GS''',
-  '''AVKBOUXTFO3MXBBK5UJD5QCQRN2FWL3O0XPZZT78''',
-  '''SANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
-  '''WB4FUG4PP2278KK579EN4NDP150CPYOG6DN42MP6JF8IAJ4PON4RC7DIOH5UEFBP''',
-  '''MXFE7NSOWPN33O7UC3THY0BN03DW940CMWTLRBE2EPTI8JPX0B0CWIIDGTI4YTJ6''',
-  '''IJWZ8TIY301KPFOW3WEUJEVZ3JR11CY1''',
-  '''9Q36xF54YEOLjetayC0NBaIKgcFFmIHsS3xTZDLzZSrhTBkxUc9FDwUKfnxLWhco6oBJV1NDBjoBcDGmsZMYPt1dSA4yWpPe/JKY9pnDcsw=''', 
-  '''MXZ9DATUWRD8WCMT8AZIPYE0IEZHJJ1B8P8ZEIXC0W552DUMMTNJJH02HFGXTOVG''',
-  '''CWLBVAODE61IXNDJ40GERFOZPB3ARZDRCP4X70ID1NB28AI0OOJBTR9S4M0ACYMD''',
-  '''BILZ6YTVAZAKOGMD9270OKN3SOD9KPB7OLKEJQOJE38NBBRUJTIH7T5859DJL31Q''',
-  '''QBFYWIWZOS1I0P0R9N1JRNP1UZAOPUIR3EB4ASPZKK9IA1SFC12LTEF7OJHB05Z8''',
-  '''E6GJSHOZMFBVNHTHNB53''',
-  '''postgresql://<username>:test123@172.24.10.50/quay''',
-  '''postgresql://<username>:test123@172.24.10.50/example-restore-registry-quay-database''',
-  '''quayadmin''',
-  '''DB_URI: postgresql://restore-registry-quay-database:zLTm315muk6rz7mL4aFuLQ2Q8rAk-dB4kPHQ2WMvdyqhaZywf20503wCZfv2Ml1f15LUsDN2-0m71gnI@restore-registry-quay-database:5432/restore-registry-quay-database
-''',
-  '''DB_URI: postgresql://quay360-quay-database:0vrsIUYdhCnF8r-jwz7zR6gck6kcLLQhJ11u0dx1lz8YBk185P5NnqIBwtY22JArYLi3opdKJH2-w4aM@quay360-quay-database:5432/quay360-quay-database
-''',
-  '''XyThQKm6lMWh4O7dKdmRwMUHB9ktxPPVSRIePOY2''',
-  '''VvoFhVFp8BqcOgQ9LczE''',
-  '''DB_URI: postgresql://restore-registry-quay-database:zLTm315muk6rz7mL4aFuLQ2Q8rAk-dB4kPHQ2WMvdyqhaZywf20503wCZfv2Ml1f15LUsDN2-0m71gnI@restore-registry-quay-database:5432/restore-registry-quay-database
-''',
-  '''postgresql://quayuser:quaypass@quay-server:5432/quay''',
-  '''4b1c5663-88c6-47ac-b4a8-bb594660f08b''',
-  '''postgresql://example-registry-quay-database:OyC4zGhJMbi3yUzW1aIgOLQNW18r14nAcuJfbsjtrAXUVInj2JgwLskQPOutPCXMtlKr1UPTsIPqOEjV@example-registry-quay-database:5432/example-registry-quay-database''',
-  '''postgresql://restore-registry-quay-database:zLTm315muk6rz7mL4aFuLQ2Q8rAk-dB4kPHQ2WMvdyqhaZywf20503wCZfv2Ml1f15LUsDN2-0m71gnI@restore-registry-quay-database:5432/restore-registry-quay-database''',
-  '''postgresql://example-restore-registry-quay-database:onHl1LDsspZh4hoOL5wW1Of7GV0Kmtp2@example-restore-registry-quay-database:5432/example-restore-registry-quay-database''',
-  '''postgresql://example-restore-registry-quay-database:onHl1LDsspZh4hoOL5wW1Of7GV0Kmtp2@example-restore-registry-quay-database:5432/example-restore-registry-quay-database''',
-  '''zsk/j4zEOkQq+W0BQJdSufP+IackV8WICXB5zvdF''',
-  '''1H36Izzc90cUNVHaiaUX''',
-  '''iO1b3RUt4KKgjSimCROSPN3cEMn4TqSgsPyniMBR''',
-  '''EH67NB3Y6PTBED8H0HC6UVHGGGA3ODSE''',
-  '''fn37AZAUQH0PTsU+vlO9lS0QxPW9A/boXL4ovZjIFtlUPrBz9i4j9UDOqMjuxQ/0HTfy38goKEpG8zYXVeQh3lOFzuOjSvKic2Vq7xdtQsU=''',
-]
+    # Historical doc example values (pre-placeholder cleanup).
+    '''ANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
+    '''E6GJSHOZMFBVNHTHNB53''',
+    '''MCJ61D8KQBFS2DXM56S2''',
+    '''J5G7CCX5QCA8Q5XZLWGI7USJPSM4M5MQHJED46CF''',
+    '''IG58PX2REEY9O08IZFZE''',
+    '''2LWTWO89KH26P2CO4TWFM7PGCX4V4SUZES2CIZMR''',
+    '''6XBK7QY7ACSCN5XBM3GS''',
+    '''AVKBOUXTFO3MXBBK5UJD5QCQRN2FWL3O0XPZZT78''',
+    '''SANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI''',
+    '''WB4FUG4PP2278KK579EN4NDP150CPYOG6DN42MP6JF8IAJ4PON4RC7DIOH5UEFBP''',
+    '''MXFE7NSOWPN33O7UC3THY0BN03DW940CMWTLRBE2EPTI8JPX0B0CWIIDGTI4YTJ6''',
+    '''IJWZ8TIY301KPFOW3WEUJEVZ3JR11CY1''',
+    '''9Q36xF54YEOLjetayC0NBaIKgcFFmIHsS3xTZDLzZSrhTBkxUc9FDwUKfnxLWhco6oBJV1NDBjoBcDGmsZMYPt1dSA4yWpPe/JKY9pnDcsw=''',
+    '''MXZ9DATUWRD8WCMT8AZIPYE0IEZHJJ1B8P8ZEIXC0W552DUMMTNJJH02HFGXTOVG''',
+    '''CWLBVAODE61IXNDJ40GERFOZPB3ARZDRCP4X70ID1NB28AI0OOJBTR9S4M0ACYMD''',
+    '''BILZ6YTVAZAKOGMD9270OKN3SOD9KPB7OLKEJQOJE38NBBRUJTIH7T5859DJL31Q''',
+    '''QBFYWIWZOS1I0P0R9N1JRNP1UZAOPUIR3EB4ASPZKK9IA1SFC12LTEF7OJHB05Z8''',
+    '''postgresql://<username>:test123@172.24.10.50/quay''',
+    '''postgresql://<username>:test123@172.24.10.50/example-restore-registry-quay-database''',
+    '''postgresql://quayuser:quaypass@quay-server:5432/quay''',
+    '''4b1c5663-88c6-47ac-b4a8-bb594660f08b''',
+    '''postgresql://example-registry-quay-database:OyC4zGhJMbi3yUzW1aIgOLQNW18r14nAcuJfbsjtrAXUVInj2JgwLskQPOutPCXMtlKr1UPTsIPqOEjV@example-registry-quay-database:5432/example-registry-quay-database''',
+    '''postgresql://restore-registry-quay-database:zLTm315muk6rz7mL4aFuLQ2Q8rAk-dB4kPHQ2WMvdyqhaZywf20503wCZfv2Ml1f15LUsDN2-0m71gnI@restore-registry-quay-database:5432/restore-registry-quay-database''',
+    '''postgresql://example-restore-registry-quay-database:onHl1LDsspZh4hoOL5wW1Of7GV0Kmtp2@example-restore-registry-quay-database:5432/example-restore-registry-quay-database''',
+    '''zsk/j4zEOkQq+W0BQJdSufP+IackV8WICXB5zvdF''',
+    '''1H36Izzc90cUNVHaiaUX''',
+    '''iO1b3RUt4KKgjSimCROSPN3cEMn4TqSgsPyniMBR''',
+    '''EH67NB3Y6PTBED8H0HC6UVHGGGA3ODSE''',
+    '''fn37AZAUQH0PTsU\+vlO9lS0QxPW9A/boXL4ovZjIFtlUPrBz9i4j9UDOqMjuxQ/0HTfy38goKEpG8zYXVeQh3lOFzuOjSvKic2Vq7xdtQsU=''',
+    '''XyThQKm6lMWh4O7dKdmRwMUHB9ktxPPVSRIePOY2''',
+    '''VvoFhVFp8BqcOgQ9LczE''',
+    '''g8gPsBLxVrLo2PjmZkYBdKvcB9C7fmBz''',
+    '''eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ''',
+    '''N3wP@ssw0rd''',
+  ]
+
+  paths = [
+    '''\/example.*\.pem$''',
+
+    # Multipage HTML previews committed briefly during local doc builds.
+    '''^[a-z0-9_-]+\.html$''',
+    '''^_[a-z0-9_-]+\.html$''',
+  ]

--- a/modules/api-superuser-changeInstallUser.adoc
+++ b/modules/api-superuser-changeInstallUser.adoc
@@ -61,7 +61,7 @@ $ curl -X PUT "https://<quay-server.example.com>/api/v1/superuser/users/<usernam
   -H "Authorization: Bearer <bearer_token>" \
   -H "Content-Type: application/json" \
   -d '{
-    "password": "<N3wP@ssw0rd!>",
+    "password": "<new_password>",
     "email": "<updated-email@example.com>",
     "enabled": true
   }'

--- a/modules/builders-virtual-environment.adoc
+++ b/modules/builders-virtual-environment.adoc
@@ -81,7 +81,7 @@ When the token expires you will need to request a new token. Optionally, you can
 .Example output
 [source,terminal]
 ----
-eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ...
+<sample_account_token>...
 ----
 
 . Determine the _builder_ route by entering the following command:
@@ -247,7 +247,7 @@ BUILD_MANAGER:
         NODE_SELECTOR_LABEL_KEY: ""
         NODE_SELECTOR_LABEL_VALUE: ""
         SERVICE_ACCOUNT_NAME: quay-builder
-        SERVICE_ACCOUNT_TOKEN: "eyJhbGciOiJSUzI1NiIsImtpZCI6IldfQUJkaDVmb3ltTHZ0dGZMYjhIWnYxZTQzN2dJVEJxcDJscldSdEUtYWsifQ"
+        SERVICE_ACCOUNT_TOKEN: "<sample_account_token>"
         HTTP_PROXY: <http://10.0.0.1:80>
         HTTPS_PROXY: <http://10.0.0.1:80>
         NO_PROXY: <hostname.example.com>

--- a/modules/config-fields-quota-management.adoc
+++ b/modules/config-fields-quota-management.adoc
@@ -12,7 +12,7 @@ The following configuration fields enable and customize quota management functio
 
 **Default:** `False`
 
-| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | String | Enables system default quota reject byte allowance for all organizations. 
+| **DEFAULT_SYSTEM_REJECT_QUOTA_BYTES** | Integer | Enables system default quota reject byte allowance for all organizations. 
 
 By default, no limit is set.
 
@@ -38,7 +38,7 @@ By default, no limit is set.
 ----
 # ...
 FEATURE_QUOTA_MANAGEMENT: true
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: "100gb"
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 QUOTA_BACKFILL: true
 QUOTA_TOTAL_DELAY_SECONDS: "3600"
 PERMANENTLY_DELETE_TAGS: true

--- a/modules/org-application-create-api.adoc
+++ b/modules/org-application-create-api.adoc
@@ -35,7 +35,7 @@ $ curl -X POST "https://<quay-server.example.com>/api/v1/organization/<orgname>/
 +
 [source,terminal]
 ----
-{"name": "new-application", "description": "", "application_uri": "", "client_id": "E6GJSHOZMFBVNHTHNB53", "client_secret": "SANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI", "redirect_uri": "", "avatar_email": null}
+{"name": "new-application", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}
 ----
 
 . Use the link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#getorganizationapplications[`GET /api/v1/organization/{orgname}/applications`] endpoint to return a list of all organization applications. For example:
@@ -50,7 +50,7 @@ $ curl -X GET "https://<quay-server.example.com>/api/v1/organization/<orgname>/a
 +
 [source,terminal]
 ----
-{"applications": [{"name": "test", "description": "", "application_uri": "", "client_id": "MCJ61D8KQBFS2DXM56S2", "client_secret": "J5G7CCX5QCA8Q5XZLWGI7USJPSM4M5MQHJED46CF", "redirect_uri": "", "avatar_email": null}, {"name": "new-token", "description": "", "application_uri": "", "client_id": "IG58PX2REEY9O08IZFZE", "client_secret": "2LWTWO89KH26P2CO4TWFM7PGCX4V4SUZES2CIZMR", "redirect_uri": "", "avatar_email": null}, {"name": "second-token", "description": "", "application_uri": "", "client_id": "6XBK7QY7ACSCN5XBM3GS", "client_secret": "AVKBOUXTFO3MXBBK5UJD5QCQRN2FWL3O0XPZZT78", "redirect_uri": "", "avatar_email": null}, {"name": "new-application", "description": "", "application_uri": "", "client_id": "E6GJSHOZMFBVNHTHNB53", "client_secret": "SANSWCWSGLVAUQ60L4Q4CEO3C1QAYGEXZK2VKJNI", "redirect_uri": "", "avatar_email": null}]}
+{"applications": [{"name": "test", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}, {"name": "new-token", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}, {"name": "second-token", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}, {"name": "new-application", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}]}
 ----
 +
 Applications can also be returned for a specific client using the link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#getorganizationapplication[`GET /api/v1/organization/{orgname}/applications/{client_id}`] endpoint. For example:
@@ -65,7 +65,7 @@ $ curl -X GET "https://<quay-server.example.com>/api/v1/organization/<orgname>/a
 +
 [source,terminal]
 ----
-{"name": "test", "description": "", "application_uri": "", "client_id": "MCJ61D8KQBFS2DXM56S2", "client_secret": "J5G7CCX5QCA8Q5XZLWGI7USJPSM4M5MQHJED46CF", "redirect_uri": "", "avatar_email": null}
+{"name": "test", "description": "", "application_uri": "", "client_id": "<client_id>", "client_secret": "<client_secret>", "redirect_uri": "", "avatar_email": null}
 ----
 
 . After creation, organization applications can be updated, for example, if you want to add a redirect URI or a new description, using the link:https://docs.redhat.com/en/documentation/red_hat_quay/{producty}/html-single/red_hat_quay_api_reference/index#updateorganizationapplication[`PUT /api/v1/organization/{orgname}/applications/{client_id}`] endpoint:

--- a/modules/setting-default-quota.adoc
+++ b/modules/setting-default-quota.adoc
@@ -15,7 +15,7 @@ The following procedure shows you how to configure a system-wide default quota.
 [source,yaml]
 ----
 # ...
-DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 100gb
+DEFAULT_SYSTEM_REJECT_QUOTA_BYTES: 107374182400
 # ...
 ----
 


### PR DESCRIPTION
## Summary
Backport of https://github.com/quay/quay-docs/pull/1812 to `redhat-3.17`.

- Replace realistic-looking OAuth, JWT, and password placeholders in documentation examples with obvious placeholders.
- Update `.gitleaks.toml` allowlist for documentation examples and generated HTML preview artifacts.
- Ignore local root-level `*.html` preview output in `.gitignore`.

## Test plan
- [ ] Verify only applicable modules for this release branch were updated
- [ ] Confirm rendered examples still read clearly with placeholder values


Made with [Cursor](https://cursor.com)